### PR TITLE
Rename the crate name 'furiosa-device-api' to 'furiosa-device' (fix #10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "furiosa-device-api"
+name = "furiosa-device"
 version = "0.1.0"
 dependencies = [
  "array_tool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "furiosa-device-api"
+name = "furiosa-device"
 version = "0.1.0"
 authors = ["FuriosaAI SW Team <pkg@furiosa.ai>"]
 edition = "2021"

--- a/bin/list_npu.rs
+++ b/bin/list_npu.rs
@@ -1,7 +1,7 @@
 use cli_table::{print_stdout, Cell, Style, Table};
 use itertools::join;
 
-use furiosa_device_api::{list_devices, DeviceError};
+use furiosa_device::{list_devices, DeviceError};
 
 #[tokio::main]
 async fn main() -> Result<(), DeviceError> {


### PR DESCRIPTION
https://github.com/furiosa-ai/device-api/issues/10