### PR TITLE
Add get_device and refactor DeviceFile to have a device index

### DIFF
--- a/src/devfs.rs
+++ b/src/devfs.rs
@@ -1,6 +1,11 @@
-use crate::{DeviceError, DeviceResult};
+use std::fs::FileType;
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
+
 use lazy_static::lazy_static;
 use regex::{Match, Regex};
+
+use crate::{DeviceError, DeviceResult};
 
 lazy_static! {
     // Update MATCH_PATTERN_NUM when you change this pattern
@@ -9,6 +14,19 @@ lazy_static! {
 }
 
 const MATCH_PATTERN_NUM: usize = 6;
+
+pub(crate) fn path<P: AsRef<Path>>(base_path: P, filename: &str) -> PathBuf {
+    base_path.as_ref().join(filename)
+}
+
+pub(crate) fn is_character_device(file_type: FileType) -> bool {
+    // allow just a file too for unit testing
+    if cfg!(test) {
+        file_type.is_file()
+    } else {
+        file_type.is_char_device()
+    }
+}
 
 pub(crate) fn parse_indices<S: AsRef<str>>(filename: S) -> DeviceResult<(u8, Vec<u8>)> {
     let name = filename.as_ref();

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,12 +3,14 @@ use std::io;
 
 use thiserror::Error;
 
-use crate::DeviceError::IncompatibleDriver;
+use crate::DeviceError::{IncompatibleDriver, IoError};
 
 pub type DeviceResult<T> = Result<T, DeviceError>;
 
 #[derive(Debug, Error)]
 pub enum DeviceError {
+    #[error("Device {name} not found")]
+    DeviceNotFound { name: String },
     #[error("IoError: {cause}")]
     IoError { cause: io::Error },
     #[error("Unknown architecture: {arch}")]
@@ -18,9 +20,22 @@ pub enum DeviceError {
 }
 
 impl DeviceError {
+    pub fn file_not_found<F: Display>(file: F) -> DeviceError {
+        use io::ErrorKind;
+        IoError {
+            cause: io::Error::new(ErrorKind::NotFound, format!("{} not found", file)),
+        }
+    }
+
     pub fn unrecognized_file<F: Display>(file: F) -> DeviceError {
         IncompatibleDriver {
             cause: format!("{} file cannot be recognized", file),
+        }
+    }
+
+    pub fn invalid_device_file<F: Display>(file: F) -> DeviceError {
+        IncompatibleDriver {
+            cause: format!("{} is not a valid device file", file),
         }
     }
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -112,7 +112,7 @@ pub(crate) fn find_devices_in(
                 .iter()
                 .filter(|d| d.mode() == config.mode)
             {
-                for idx in dev_file.indices() {
+                for idx in dev_file.core_indices() {
                     if allocated.get(&device.device_index()).unwrap().contains(idx) {
                         continue 'inner;
                     }
@@ -121,7 +121,7 @@ pub(crate) fn find_devices_in(
                 found.push(dev_file.clone());
 
                 let used = allocated.get_mut(&device.device_index()).unwrap();
-                used.extend(dev_file.indices());
+                used.extend(dev_file.core_indices());
                 if dev_file.is_multicore() {
                     used.extend(device.cores());
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,30 @@ pub async fn find_devices(config: &DeviceConfig) -> DeviceResult<Vec<DeviceFile>
     let devices = expand_status(list_devices().await?).await?;
     find_devices_in(config, &devices)
 }
+
+/// Return a specific device if it exists.
+///
+/// # Arguments
+///
+/// * `device_name` - A device name (e.g., npu0, npu0pe0, npu0pe0-1)
+pub async fn get_device<S: AsRef<str>>(device_name: S) -> DeviceResult<DeviceFile> {
+    get_device_with("/dev", device_name.as_ref()).await
+}
+
+pub(crate) async fn get_device_with(devfs: &str, device_name: &str) -> DeviceResult<DeviceFile> {
+    let path = devfs::path(devfs, device_name);
+    if !path.exists() {
+        return Err(DeviceError::DeviceNotFound {
+            name: device_name.to_string(),
+        });
+    }
+
+    let file = tokio::fs::File::open(&path).await?;
+    if !devfs::is_character_device(file.metadata().await?.file_type()) {
+        return Err(DeviceError::invalid_device_file(path.display()));
+    }
+
+    devfs::parse_indices(path.file_name().expect("not a file").to_string_lossy())?;
+
+    DeviceFile::try_from(&path)
+}


### PR DESCRIPTION
This PR tries to make DeviceFile more practical in real projects. Usually, the device index, core indices both are used when we get the device in other projects. Also, in many cases, we still need to get a device from the specific name.

This PR depends on https://github.com/furiosa-ai/device-api/pull/15. So, I'll make this PR ready after #15 is accepted.