### PR TITLE
change visibility of 'arch' module

### DIFF
--- a/src/arch.rs
+++ b/src/arch.rs
@@ -25,7 +25,7 @@ impl Display for Arch {
 
 #[cfg(test)]
 mod tests {
-    use crate::arch::Arch;
+    use super::*;
     use std::str::FromStr;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ pub use crate::error::{DeviceError, DeviceResult};
 pub use crate::find::DeviceConfig;
 use crate::find::{expand_status, find_devices_in};
 use crate::list::list_devices_with;
-pub use crate::status::DeviceStatus;
 
 mod arch;
 #[cfg(feature = "blocking")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
-pub use crate::device::{Device, DeviceFile};
+pub use crate::arch::Arch;
+pub use crate::device::{CoreStatus, Device, DeviceFile, DeviceMode};
 pub use crate::error::{DeviceError, DeviceResult};
 pub use crate::find::DeviceConfig;
 use crate::find::{expand_status, find_devices_in};
 use crate::list::list_devices_with;
+pub use crate::status::DeviceStatus;
 
 mod arch;
 #[cfg(feature = "blocking")]


### PR DESCRIPTION
`arch` module is private and cannot be accessed from outside.
Pattern matching may be required for the variant of the `Arch` enum, so it should be public.

```rust
let arch = device.arch();
match arch {
    furiosa_device::arch::Arch::Warboy |
    furiosa_device::arch::Arch::WarboyB0 => {
        // do something...
    },
    furiosa_device::arch::Arch::U250 => {
        // do something...
    },
    _ => ()
}
```