### PR TITLE
minor fix in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! Add this to your 'Cargo.toml':
 //! ```toml
 //! [dependencies]
-//! furiosa_device = "0.1"
+//! furiosa-device = "0.1"
 //! ```
 //!
 //! ## Listing devices from the system


### PR DESCRIPTION
This crate is specified as `furiosa-device`, not `furiosa_device` (in Cargo.toml). Fixes it.