### PR TITLE
Derive serde to public items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "regex",
+ "serde",
  "strum",
  "strum_macros",
  "thiserror",
@@ -379,6 +380,20 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_derive_internals"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1"
 tokio = { version = "1.17.0", features = ["fs", "rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
+serde = {version = "1.0", features = ["derive"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use strum_macros::{AsRefStr, EnumString};
 
 /// Enum for the NPU architecture.
-#[derive(AsRefStr, Clone, Copy, Debug, EnumString, Eq, PartialEq)]
+#[derive(AsRefStr, Clone, Copy, Debug, EnumString, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Arch {
     Warboy,
     WarboyB0,

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,11 +6,11 @@ use std::path::PathBuf;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
+use serde::{Deserialize, Serialize};
+
 use crate::arch::Arch;
 use crate::status::{get_device_status, DeviceStatus};
 use crate::{devfs, sysfs, DeviceError, DeviceResult};
-
-#[derive(Debug, Eq, PartialEq)]
 
 /// Abstraction for a single Furiosa NPU device.
 ///
@@ -34,6 +34,7 @@ use crate::{devfs, sysfs, DeviceError, DeviceResult};
 /// method, which returns a list of [`DeviceFile`]s.
 /// Each [`DeviceFile`] again offers [`mode`][DeviceFile::mode] method to
 /// identify its [`DeviceMode`].
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Device {
     device_index: u8,
     device_info: DeviceInfo,
@@ -163,7 +164,7 @@ impl PartialOrd for Device {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DeviceInfo {
     arch: Arch,
     busname: Option<String>,
@@ -225,7 +226,7 @@ impl TryFrom<HashMap<&'static str, String>> for DeviceInfo {
 }
 
 /// Enum for NPU core status.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CoreStatus {
     Available,
     Occupied(String),
@@ -245,7 +246,7 @@ impl Display for CoreStatus {
 pub(crate) type CoreIdx = u8;
 
 /// An abstraction for a device file and its mode.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct DeviceFile {
     pub(crate) device_index: u8,
     pub(crate) core_indices: Vec<CoreIdx>,
@@ -323,7 +324,7 @@ impl TryFrom<&PathBuf> for DeviceFile {
 }
 
 /// Enum for NPU's operating mode.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, enum_utils::FromStr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, enum_utils::FromStr, Serialize, Deserialize)]
 #[enumeration(case_insensitive)]
 pub enum DeviceMode {
     Single,


### PR DESCRIPTION
As guided by the [Rust API guideline](https://rust-lang.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde), implement serde's `Serialize`, `Deserialize` to public data structures.