### PR TITLE
Reimpl find_devices()

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -154,12 +154,11 @@ pub fn get_status_all(device: &Device) -> DeviceResult<HashMap<CoreIdx, CoreStat
 
     for file in &device.dev_files {
         if get_device_status(&file.path)? == DeviceStatus::Occupied {
-            for core in file.core_indices.iter().chain(
-                file.is_multicore()
-                    .then(|| device.cores.iter())
-                    .into_iter()
-                    .flatten(),
-            ) {
+            for core in device
+                .cores()
+                .iter()
+                .filter(|c| file.core_range().contains(*c))
+            {
                 status_map.insert(*core, CoreStatus::Occupied(file.to_string()));
             }
         }

--- a/src/device.rs
+++ b/src/device.rs
@@ -277,7 +277,7 @@ impl Ord for CoreRange {
             }
             CoreRange::Range(r) => match other {
                 CoreRange::All => std::cmp::Ordering::Greater,
-                CoreRange::Range(ro) => r.cmp(ro),
+                CoreRange::Range(other) => (r.1 - r.0).cmp(&(other.1 - other.0)).then(r.cmp(other)),
             },
         }
     }
@@ -396,6 +396,20 @@ pub enum DeviceMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_core_range_ordering() {
+        let all = CoreRange::All;
+        let core0 = CoreRange::Range((0, 0));
+        let core0_1 = CoreRange::Range((0, 1));
+        let core0_3 = CoreRange::Range((0, 3));
+        let core2_3 = CoreRange::Range((2, 3));
+
+        assert!(all < core0);
+        assert!(core0 < core0_1);
+        assert!(core0_1 < core2_3);
+        assert!(core2_3 < core0_3);
+    }
 
     #[test]
     fn test_try_from() -> Result<(), DeviceError> {

--- a/src/device.rs
+++ b/src/device.rs
@@ -401,12 +401,14 @@ mod tests {
     fn test_core_range_ordering() {
         let all = CoreRange::All;
         let core0 = CoreRange::Range((0, 0));
+        let core1 = CoreRange::Range((1, 1));
         let core0_1 = CoreRange::Range((0, 1));
         let core0_3 = CoreRange::Range((0, 3));
         let core2_3 = CoreRange::Range((2, 3));
 
         assert!(all < core0);
-        assert!(core0 < core0_1);
+        assert!(core0 < core1);
+        assert!(core1 < core0_1);
         assert!(core0_1 < core2_3);
         assert!(core2_3 < core0_3);
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -116,7 +116,7 @@ impl Device {
     /// Examine a specific core of the device, whether it is available or not.
     pub async fn get_status_core(&self, core: CoreIdx) -> DeviceResult<CoreStatus> {
         for file in &self.dev_files {
-            if (file.is_multicore() || file.core_indices().contains(&core))
+            if (file.core_range().contains(&core))
                 && get_device_status(&file.path).await? == DeviceStatus::Occupied
             {
                 return Ok(CoreStatus::Occupied(file.to_string()));
@@ -129,17 +129,9 @@ impl Device {
     pub async fn get_status_all(&self) -> DeviceResult<HashMap<CoreIdx, CoreStatus>> {
         let mut status_map = self.new_status_map();
 
-        for file in &self.dev_files {
-            if get_device_status(&file.path).await? == DeviceStatus::Occupied {
-                for core in file.core_indices.iter().chain(
-                    file.is_multicore()
-                        .then(|| self.cores.iter())
-                        .into_iter()
-                        .flatten(),
-                ) {
-                    status_map.insert(*core, CoreStatus::Occupied(file.to_string()));
-                }
-            }
+        for core in self.cores() {
+            let status = self.get_status_core(*core).await?;
+            status_map.insert(*core, status);
         }
         Ok(status_map)
     }
@@ -258,11 +250,67 @@ impl Display for CoreStatus {
 
 pub(crate) type CoreIdx = u8;
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum CoreRange {
+    All,
+    Range((u8, u8)),
+}
+
+impl CoreRange {
+    pub fn contains(&self, idx: &CoreIdx) -> bool {
+        match self {
+            CoreRange::All => true,
+            CoreRange::Range((s, e)) => (*s..=*e).contains(idx),
+        }
+    }
+}
+
+impl Ord for CoreRange {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self {
+            CoreRange::All => {
+                if self == other {
+                    std::cmp::Ordering::Equal
+                } else {
+                    std::cmp::Ordering::Less
+                }
+            }
+            CoreRange::Range(r) => match other {
+                CoreRange::All => std::cmp::Ordering::Greater,
+                CoreRange::Range(ro) => r.cmp(ro),
+            },
+        }
+    }
+}
+
+impl PartialOrd for CoreRange {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl From<u8> for CoreRange {
+    fn from(id: u8) -> Self {
+        Self::Range((id, id))
+    }
+}
+
+impl TryFrom<(u8, u8)> for CoreRange {
+    type Error = ();
+    fn try_from(v: (u8, u8)) -> Result<Self, Self::Error> {
+        if v.0 < v.1 {
+            Ok(Self::Range(v))
+        } else {
+            Err(())
+        }
+    }
+}
+
 /// An abstraction for a device file and its mode.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct DeviceFile {
     pub(crate) device_index: u8,
-    pub(crate) core_indices: Vec<CoreIdx>,
+    pub(crate) core_range: CoreRange,
     pub(crate) path: PathBuf,
     pub(crate) mode: DeviceMode,
 }
@@ -294,18 +342,14 @@ impl DeviceFile {
         self.device_index
     }
 
-    /// Returns indices of cores this device file may occupy.
-    pub fn core_indices(&self) -> &Vec<CoreIdx> {
-        &self.core_indices
+    /// Returns the range of cores this device file may occupy.
+    pub fn core_range(&self) -> CoreRange {
+        self.core_range
     }
 
     /// Return the mode of this device file.
     pub fn mode(&self) -> DeviceMode {
         self.mode
-    }
-
-    pub(crate) fn is_multicore(&self) -> bool {
-        self.mode == DeviceMode::MultiCore
     }
 }
 
@@ -321,15 +365,19 @@ impl TryFrom<&PathBuf> for DeviceFile {
 
         let (device_index, core_indices) = devfs::parse_indices(&file_name)?;
 
-        let mode = match core_indices.len() {
-            0 => DeviceMode::MultiCore,
-            1 => DeviceMode::Single,
-            _ => DeviceMode::Fusion,
+        let (mode, core_range) = match core_indices.len() {
+            0 => (DeviceMode::MultiCore, CoreRange::All),
+            1 => (DeviceMode::Single, CoreRange::from(core_indices[0])),
+            n => (
+                DeviceMode::Fusion,
+                CoreRange::try_from((core_indices[0], core_indices[n - 1]))
+                    .map_err(|_| DeviceError::unrecognized_file(path.to_string_lossy()))?,
+            ),
         };
 
         Ok(DeviceFile {
             device_index,
-            core_indices,
+            core_range,
             path: path.clone(),
             mode,
         })
@@ -356,7 +404,7 @@ mod tests {
             DeviceFile {
                 device_index: 0,
                 path: PathBuf::from("./npu0"),
-                core_indices: vec![],
+                core_range: CoreRange::All,
                 mode: DeviceMode::MultiCore,
             }
         );
@@ -366,7 +414,7 @@ mod tests {
             DeviceFile {
                 device_index: 0,
                 path: PathBuf::from("./npu0pe0"),
-                core_indices: vec![0],
+                core_range: CoreRange::Range((0, 0)),
                 mode: DeviceMode::Single,
             }
         );
@@ -375,7 +423,7 @@ mod tests {
             DeviceFile {
                 device_index: 0,
                 path: PathBuf::from("./npu0pe1"),
-                core_indices: vec![1],
+                core_range: CoreRange::Range((1, 1)),
                 mode: DeviceMode::Single,
             }
         );
@@ -384,7 +432,7 @@ mod tests {
             DeviceFile {
                 device_index: 0,
                 path: PathBuf::from("./npu0pe0-1"),
-                core_indices: vec![0, 1],
+                core_range: CoreRange::Range((0, 1)),
                 mode: DeviceMode::Fusion,
             }
         );
@@ -393,7 +441,7 @@ mod tests {
             DeviceFile {
                 device_index: 0,
                 path: PathBuf::from("./npu0pe0-2"),
-                core_indices: vec![0, 1, 2],
+                core_range: CoreRange::Range((0, 2)),
                 mode: DeviceMode::Fusion,
             }
         );

--- a/src/find.rs
+++ b/src/find.rs
@@ -10,8 +10,8 @@ use nom::sequence::{delimited, separated_pair};
 use nom::Parser;
 
 use crate::arch::Arch;
-use crate::device::{CoreIdx, CoreStatus, Device, DeviceFile, DeviceMode};
-use crate::error::{DeviceError, DeviceResult};
+use crate::device::{CoreIdx, CoreRange, CoreStatus, Device, DeviceFile, DeviceMode};
+use crate::error::DeviceResult;
 
 /// Describes a required set of devices for [`find_devices`][crate::find_devices].
 ///
@@ -35,7 +35,7 @@ pub enum DeviceConfig {
     // TODO: Named cannot describe MultiCore yet.
     Named {
         device_id: u8,
-        core_id: CoreIdConfig,
+        core_id: CoreRange,
     },
     Unnamed {
         arch: Arch,
@@ -45,38 +45,6 @@ pub enum DeviceConfig {
     },
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum CoreIdConfig {
-    Id(u8),
-    Range(u8, u8),
-}
-
-impl CoreIdConfig {
-    fn iter(&self) -> impl Iterator<Item = u8> {
-        match self {
-            Self::Id(id) => *id..=*id,
-            Self::Range(s, e) => *s..=*e,
-        }
-    }
-}
-
-impl From<u8> for CoreIdConfig {
-    fn from(id: u8) -> Self {
-        Self::Id(id)
-    }
-}
-
-impl TryFrom<(u8, u8)> for CoreIdConfig {
-    type Error = nom::Err<()>;
-    fn try_from(v: (u8, u8)) -> Result<Self, Self::Error> {
-        if v.0 < v.1 {
-            Ok(CoreIdConfig::Range(v.0, v.1))
-        } else {
-            Err(nom::Err::Failure(()))
-        }
-    }
-}
-
 impl DeviceConfig {
     /// Returns a builder associated with Warboy NPUs.
     pub fn warboy() -> DeviceConfigBuilder<Arch, NotDetermined, NotDetermined> {
@@ -84,6 +52,35 @@ impl DeviceConfig {
             arch: Arch::Warboy,
             mode: NotDetermined,
             count: NotDetermined,
+        }
+    }
+
+    pub(crate) fn fit(&self, device: &Device, device_file: &DeviceFile) -> bool {
+        match self {
+            Self::Named { device_id, core_id } => {
+                device.device_index() == *device_id && device_file.core_range() == *core_id
+            }
+            Self::Unnamed {
+                arch,
+                core_num: _,
+                mode,
+                count: _,
+            } => device.arch() == *arch && device_file.mode() == *mode,
+        }
+    }
+
+    pub(crate) fn count(&self) -> u8 {
+        match self {
+            Self::Named {
+                device_id: _,
+                core_id: _,
+            } => 1,
+            Self::Unnamed {
+                arch: _,
+                core_num: _,
+                mode: _,
+                count,
+            } => *count,
         }
     }
 }
@@ -108,9 +105,9 @@ impl FromStr for DeviceConfig {
             alt((
                 map_res(
                     separated_pair(digit_to_u8(), tag("-"), digit_to_u8()),
-                    CoreIdConfig::try_from,
+                    CoreRange::try_from,
                 ),
-                map(digit_to_u8(), CoreIdConfig::from),
+                map(digit_to_u8(), CoreRange::from),
             )),
         ))(s);
 
@@ -272,82 +269,31 @@ pub(crate) fn find_devices_in(
         );
     }
 
-    let (&config_arch, &core_num, &config_mode, &config_count) = match config {
-        DeviceConfig::Named { device_id, core_id } => {
-            let mut parent = None;
-            for device in devices {
-                if device.device_index() == *device_id {
-                    parent = Some(device);
-                }
-            }
-
-            if let Some(parent) = parent {
-                for dev_file in parent.dev_files().iter() {
-                    if dev_file
-                        .core_indices()
-                        .iter()
-                        .copied()
-                        .collect::<HashSet<u8>>()
-                        == core_id.iter().collect::<HashSet<u8>>()
-                    {
-                        for idx in dev_file.core_indices() {
-                            if allocated
-                                .get(&dev_file.device_index())
-                                .unwrap()
-                                .contains(idx)
-                            {
-                                return Ok(vec![]);
-                            }
-                        }
-                        return Ok(vec![dev_file.clone()]);
-                    }
-                }
-            }
-
-            return Err(DeviceError::DeviceNotFound {
-                name: format!("dev_id: {:?}, core_id: {:?}", device_id, core_id),
-            });
-        }
-        DeviceConfig::Unnamed {
-            arch,
-            core_num,
-            mode,
-            count,
-        } => (arch, core_num, mode, count),
-    };
-
+    let config_count = config.count();
     let mut found: Vec<DeviceFile> = Vec::with_capacity(config_count.into());
-
     'outer: for _ in 0..config_count {
         for device in devices {
-            if config_arch != device.arch() {
-                continue;
-            }
-            // early exit for multicore
-            if config_mode == DeviceMode::MultiCore
-                && !allocated.get(&device.device_index()).unwrap().is_empty()
-            {
-                continue;
-            }
+            'inner: for dev_file in device.dev_files() {
+                if !config.fit(device, dev_file) {
+                    continue 'inner;
+                }
 
-            'inner: for dev_file in device
-                .dev_files()
-                .iter()
-                .filter(|d| d.mode() == config_mode && d.core_indices().len() as u8 == core_num)
-            {
-                for idx in dev_file.core_indices() {
-                    if allocated.get(&device.device_index()).unwrap().contains(idx) {
+                let used = allocated.get_mut(&device.device_index()).unwrap();
+
+                for core in used.iter() {
+                    if dev_file.core_range().contains(core) {
                         continue 'inner;
                     }
                 }
+
                 // this dev_file is suitable
                 found.push(dev_file.clone());
-
-                let used = allocated.get_mut(&device.device_index()).unwrap();
-                used.extend(dev_file.core_indices());
-                if dev_file.is_multicore() {
-                    used.extend(device.cores());
-                }
+                used.extend(
+                    device
+                        .cores()
+                        .iter()
+                        .filter(|idx| dev_file.core_range().contains(idx)),
+                );
                 continue 'outer;
             }
         }
@@ -410,28 +356,28 @@ mod tests {
             "0:0".parse::<DeviceConfig>(),
             Ok(DeviceConfig::Named {
                 device_id: 0,
-                core_id: CoreIdConfig::Id(0)
+                core_id: CoreRange::Range((0, 0))
             })
         );
         assert_eq!(
             "0:1".parse::<DeviceConfig>(),
             Ok(DeviceConfig::Named {
                 device_id: 0,
-                core_id: CoreIdConfig::Id(1)
+                core_id: CoreRange::Range((1, 1))
             })
         );
         assert_eq!(
             "1:1".parse::<DeviceConfig>(),
             Ok(DeviceConfig::Named {
                 device_id: 1,
-                core_id: CoreIdConfig::Id(1)
+                core_id: CoreRange::Range((1, 1))
             })
         );
         assert_eq!(
             "0:0-1".parse::<DeviceConfig>(),
             Ok(DeviceConfig::Named {
                 device_id: 0,
-                core_id: CoreIdConfig::Range(0, 1)
+                core_id: CoreRange::Range((0, 1))
             })
         );
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -50,18 +50,15 @@ pub(crate) fn collect_devices(
 
     for path in paths {
         let file = DeviceFile::try_from(&path)?;
-        cores.extend(file.core_indices());
+        let (_, core_indices) =
+            devfs::parse_indices(path.file_name().unwrap().to_string_lossy().to_string())?;
+        cores.extend(core_indices);
         dev_files.push(file);
     }
 
     let mut cores: Vec<u8> = cores.into_iter().collect();
     cores.sort_unstable();
-    dev_files.sort_by(|x, y| {
-        x.core_indices()
-            .len()
-            .cmp(&y.core_indices().len())
-            .then(x.path().cmp(y.path()))
-    });
+    dev_files.sort_by_key(|x| x.core_range());
 
     Ok(Device::new(device_info, hwmon_fetcher, cores, dev_files))
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -50,8 +50,7 @@ pub(crate) fn collect_devices(
 
     for path in paths {
         let file = DeviceFile::try_from(&path)?;
-        let (_, core_indices) =
-            devfs::parse_indices(path.file_name().unwrap().to_string_lossy().to_string())?;
+        let (_, core_indices) = devfs::parse_indices(path.file_name().unwrap().to_string_lossy())?;
         cores.extend(core_indices);
         dev_files.push(file);
     }


### PR DESCRIPTION
기존에 `MultiCore` Mode의 `DeviceFile`에 대해 `.core_indices()` 함수를 수행하면 빈 벡터를 리턴했습니다.
이는 실제로 multicore mode가 점유하는 코어 정보(=all) 와 맞지 않지만,
해당 파일의 이름만 보고 core list를 가져오는 것이 까다로워서 수정되지 않았고
대신 .is_multicore() 같은 보조 함수를 써서 필요할 때마다 예외 처리가 이루어졌습니다.

여기에서는 CoreRange라는 enum 을 넣어서 DeviceFile이 점유하는 core 정보를 나타내게 하고,
DeviceConfig가 사용하던 비슷한 용도의 필드도 통합 시켰습니다.
multicore device의 경우 `All`이라는 variant를 가집니다.
```rust
#[derive(Debug, Eq, PartialEq, Clone, Copy)]
pub enum CoreRange {
    All,
    Range((u8, u8)),
}
```

그리고 이를 기반으로 DeviceConfig에 .fit()이라는 함수를 추가해서 find 함수 구현을 단순화 합니다. 이 함수의 signature는 다음과 같이 생겼습니다.
```rust
pub(crate) fn fit(&self, device: &Device, device_file: &DeviceFile) -> bool ;
```
파라미터로 `DeviceFile`만 받으면 좋겠지만 그러려면 #6 이 해결되어야 하고, 지금은 Device를 같이 받는 형태입니다.