### PR TITLE
Trivial improvement to expose more public structs

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -372,7 +372,7 @@ impl Display for CoreStatus {
 
 pub(crate) type CoreIdx = u8;
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum CoreRange {
     All,
     Range((u8, u8)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use crate::arch::Arch;
-pub use crate::device::{CoreStatus, Device, DeviceFile, DeviceMode};
+pub use crate::device::{CoreStatus, CoreRange, Device, DeviceFile, DeviceMode};
 pub use crate::error::{DeviceError, DeviceResult};
 use crate::find::{expand_status, find_devices_in};
 pub use crate::find::{DeviceConfig, DeviceConfigBuilder};


### PR DESCRIPTION
CoreRange can be used in other crates. This trivial changes would be helpful for other projects which directly make good use of core ranges. FYI, [furiosa-rt#37](https://github.com/furiosa-ai/furiosa-runtime/pull/37) depends on this change.