### PR TITLE
Remove unnecessary async keyword in hwmon handler

### DIFF
--- a/bin/list_hwmon.rs
+++ b/bin/list_hwmon.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), DeviceError> {
 
         println!("-- npu{} --", device.device_index());
         println!("Current");
-        for sensor_value in fetcher.read_currents().await? {
+        for sensor_value in fetcher.read_currents()? {
             println!(
                 "  {:16} {:7.2} A",
                 sensor_value.label,
@@ -15,7 +15,7 @@ async fn main() -> Result<(), DeviceError> {
             );
         }
         println!("Voltage");
-        for sensor_value in fetcher.read_voltages().await? {
+        for sensor_value in fetcher.read_voltages()? {
             println!(
                 "  {:16} {:7.2} V",
                 sensor_value.label,
@@ -23,7 +23,7 @@ async fn main() -> Result<(), DeviceError> {
             );
         }
         println!("Power");
-        for sensor_value in fetcher.read_powers_average().await? {
+        for sensor_value in fetcher.read_powers_average()? {
             println!(
                 "  {:16} {:7.2} W",
                 sensor_value.label,
@@ -31,7 +31,7 @@ async fn main() -> Result<(), DeviceError> {
             );
         }
         println!("Temperature");
-        for sensor_value in fetcher.read_temperatures().await? {
+        for sensor_value in fetcher.read_temperatures()? {
             println!(
                 "  {:16} {:7}°C",
                 sensor_value.label,

--- a/bin/list_proc.rs
+++ b/bin/list_proc.rs
@@ -2,8 +2,7 @@ use cli_table::{print_stdout, Cell, Style, Table};
 
 use furiosa_device::{proc, DeviceError};
 
-#[tokio::main]
-async fn main() -> Result<(), DeviceError> {
+fn main() -> Result<(), DeviceError> {
     let mut rows = vec![];
 
     for process in proc::scan_processes()? {

--- a/src/list.rs
+++ b/src/list.rs
@@ -29,7 +29,7 @@ pub(crate) async fn list_devices_with(devfs: &str, sysfs: &str) -> DeviceResult<
 
             // Since busname is a required field, it is guaranteed to exist.
             let busname = device_info.get(npu_mgmt::BUSNAME).unwrap();
-            let hwmon_fetcher = crate::hwmon::Fetcher::new(sysfs, idx, &busname).await?;
+            let hwmon_fetcher = crate::hwmon::Fetcher::new(sysfs, idx, &busname)?;
 
             let device = collect_devices(device_info, hwmon_fetcher, paths)?;
             devices.push(device);


### PR DESCRIPTION
Functions in `hwmon` module have `async` keyword but doesn't really work meaningfully. (just sequential async-await)
For convenience, it would be better to change to sync. (Some other APIs already applied)
( #41 )