### PR TITLE
Add a new interface: DeviceConfig::from_env()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +255,7 @@ dependencies = [
  "cli-table",
  "enum-display-derive",
  "enum-utils",
+ "eyre",
  "itertools",
  "lazy_static",
  "memoize",
@@ -299,6 +310,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ array_tool = "1"
 cli-table = "0.4"
 enum-display-derive = "0.1"
 enum-utils = "0.1.2"
+eyre = "0.6.8"
 itertools = "0.10"
 lazy_static = "1.4"
 memoize = { version = "0.3.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ array_tool = "1"
 cli-table = "0.4"
 enum-display-derive = "0.1"
 enum-utils = "0.1.2"
-eyre = "0.6.8"
 itertools = "0.10"
 lazy_static = "1.4"
 memoize = { version = "0.3.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ tokio = { version = "1.17.0", features = ["fs", "rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 
+[dev-dependencies]
+eyre = "0.6"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-09-29"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#group_imports
+group_imports = "StdExternalCrate"

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -174,8 +174,11 @@ mod tests {
 
         // looking for 5 different cores should fail
         let config = DeviceConfig::warboy().single().count(5);
-        let found = find_devices_in(&config, &devices_with_statuses)?;
-        assert_eq!(found, vec![]);
+        let found = find_devices_in(&config, &devices_with_statuses);
+        match found {
+            Ok(_) => panic!("looking for 5 different cores should fail"),
+            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
+        }
 
         // try lookup 2 different fused cores
         let config = DeviceConfig::warboy().fused().count(2);
@@ -186,8 +189,11 @@ mod tests {
 
         // looking for 3 different fused cores should fail
         let config = DeviceConfig::warboy().fused().count(3);
-        let found = find_devices_in(&config, &devices_with_statuses)?;
-        assert_eq!(found, vec![]);
+        let found = find_devices_in(&config, &devices_with_statuses);
+        match found {
+            Ok(_) => panic!("looking for 3 different fused cores should fail"),
+            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
+        }
 
         Ok(())
     }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,10 +1,21 @@
 use super::inner::{Config, DeviceConfigInner};
 use crate::arch::Arch;
 use crate::device::DeviceMode;
-use crate::DeviceConfig;
+use crate::{DeviceConfig, DeviceError};
 
 pub struct NotDetermined {
     pub(crate) _priv: (),
+}
+
+impl TryInto<DeviceConfig> for NotDetermined {
+    type Error = DeviceError;
+
+    fn try_into(self) -> Result<DeviceConfig, Self::Error> {
+        Err(DeviceError::parse_error(
+            "",
+            "fallback device config is not set",
+        ))
+    }
 }
 
 impl From<NotDetermined> for Arch {

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,4 +1,4 @@
-use super::inner::Config;
+use super::inner::{Config, DeviceConfigInner};
 use crate::arch::Arch;
 use crate::device::DeviceMode;
 use crate::DeviceConfig;
@@ -82,11 +82,13 @@ where
         };
 
         DeviceConfig {
-            inner: Config::Unnamed {
-                arch: Arch::from(self.arch),
-                core_num,
-                mode,
-                count: u8::from(self.count),
+            inner: DeviceConfigInner {
+                cfgs: vec![Config::Unnamed {
+                    arch: Arch::from(self.arch),
+                    core_num,
+                    mode,
+                    count: u8::from(self.count),
+                }],
             },
         }
     }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,4 +1,4 @@
-use super::inner::DeviceConfigInner;
+use super::inner::Config;
 use crate::arch::Arch;
 use crate::device::DeviceMode;
 use crate::DeviceConfig;
@@ -82,7 +82,7 @@ where
         };
 
         DeviceConfig {
-            inner: DeviceConfigInner::Unnamed {
+            inner: Config::Unnamed {
                 arch: Arch::from(self.arch),
                 core_num,
                 mode,

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -49,7 +49,7 @@ impl EnvBuilder<NotDetermined> {
     }
 }
 
-impl<T: TryInto<DeviceConfig, Error = DeviceError>> EnvBuilder<T> {
+impl<T: TryInto<DeviceConfig, Error: Into<DeviceError>>> EnvBuilder<T> {
     pub fn build(self) -> DeviceResult<DeviceConfig> {
         for item in self.list {
             match item {
@@ -70,6 +70,6 @@ impl<T: TryInto<DeviceConfig, Error = DeviceError>> EnvBuilder<T> {
             }
         }
 
-        self.fallback.try_into()
+        self.fallback.try_into().map_err(|e| e.into())
     }
 }

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -9,6 +9,7 @@ enum Source {
     Try(String),
 }
 
+/// A struct for building `DeviceConfig` from an environment variable.
 pub struct EnvBuilder<T> {
     list: Vec<Source>,
     fallback: T,
@@ -57,6 +58,7 @@ impl EnvBuilder<NotDetermined> {
 }
 
 impl<T: TryInto<DeviceConfig, Error: Into<DeviceError>>> EnvBuilder<T> {
+    /// Finalize the config.
     pub fn build(self) -> DeviceResult<DeviceConfig> {
         for item in self.list {
             match item {

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -22,11 +22,14 @@ impl EnvBuilder<NotDetermined> {
         }
     }
 
+    /// Provides a fallback env variable to the builder when the previous options are empty.
     pub fn or_env<K: ToString>(mut self, key: K) -> Self {
         self.list.push(Source::Env(key.to_string()));
         self
     }
 
+    /// Provides a fallback option to the builder when the previous options are empty.
+    /// The builder will try `from_str()` method if the item is `Some`.
     pub fn or_try<T: ToString>(mut self, item: Option<T>) -> Self {
         if let Some(s) = &item {
             self.list.push(Source::Try(s.to_string()))
@@ -34,6 +37,8 @@ impl EnvBuilder<NotDetermined> {
         self
     }
 
+    /// Provides a fallback config to the builder when the previous options are empty.
+    /// Note that incorrect syntax causes the build to fail rather than fallback.
     pub fn or(self, fallback: DeviceConfig) -> EnvBuilder<DeviceConfig> {
         EnvBuilder::<DeviceConfig> {
             list: self.list,
@@ -41,6 +46,8 @@ impl EnvBuilder<NotDetermined> {
         }
     }
 
+    /// Provides a fallback default config to the builder when the previous options are empty.
+    /// Note that incorrect syntax causes the build to fail rather than fallback.
     pub fn or_default(self) -> EnvBuilder<DeviceConfig> {
         EnvBuilder::<DeviceConfig> {
             list: self.list,

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,0 +1,64 @@
+use std::str::FromStr;
+
+use super::builder::NotDetermined;
+use crate::{DeviceConfig, DeviceError};
+
+#[derive(Debug)]
+enum Source {
+    Env(String),
+    Try(String),
+}
+
+struct EnvBuilder<T> {
+    list: Vec<Source>,
+    fallback: T,
+}
+
+impl EnvBuilder<NotDetermined> {
+    pub fn or_env<K: ToString>(mut self, key: K) -> Self {
+        self.list.push(Source::Env(key.to_string()));
+        self
+    }
+
+    pub fn or_try<T: ToString>(mut self, item: Option<T>) -> Self {
+        if let Some(s) = &item {
+            self.list.push(Source::Try(s.to_string()))
+        }
+        self
+    }
+
+    pub fn or(mut self, fallback: DeviceConfig) -> EnvBuilder<DeviceConfig> {
+        EnvBuilder::<DeviceConfig> {
+            list: self.list,
+            fallback,
+        }
+    }
+
+    pub fn or_default(mut self) -> EnvBuilder<DeviceConfig> {
+        EnvBuilder::<DeviceConfig> {
+            list: self.list,
+            fallback: Default::default(),
+        }
+    }
+}
+
+impl<T: TryInto<DeviceConfig>> EnvBuilder<T>
+where
+    <T as TryInto<DeviceConfig>>::Error: std::fmt::Debug,
+{
+    fn build(self) -> eyre::Result<DeviceConfig> {
+        for item in self.list {
+            match item {
+                Source::Env(key) => match std::env::var(key) {
+                    Ok(value) => return DeviceConfig::from_str(value.as_str()),
+                    Err(std::env::VarError::NotPresent) => continue,
+                    Err(err) => eyre::bail!("cause: {}", err), // TODO
+                },
+                Source::Try(item) => return DeviceConfig::from_str(item.as_str()),
+            }
+        }
+
+        let config = self.fallback.try_into().unwrap();
+        Ok(config)
+    }
+}

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -6,7 +6,7 @@ use crate::{DeviceConfig, DeviceError, DeviceResult};
 #[derive(Debug)]
 enum Source {
     Env(String),
-    Try(String),
+    Str(String),
 }
 
 /// A struct for building `DeviceConfig` from an environment variable.
@@ -33,7 +33,7 @@ impl EnvBuilder<NotDetermined> {
     /// The builder will try `from_str()` method if the item is `Some`.
     pub fn or_try<T: ToString>(mut self, item: Option<T>) -> Self {
         if let Some(s) = &item {
-            self.list.push(Source::Try(s.to_string()))
+            self.list.push(Source::Str(s.to_string()))
         }
         self
     }
@@ -75,7 +75,7 @@ impl<T: TryInto<DeviceConfig, Error: Into<DeviceError>>> EnvBuilder<T> {
                         ))
                     }
                 },
-                Source::Try(item) => return DeviceConfig::from_str(item.as_str()),
+                Source::Str(item) => return DeviceConfig::from_str(item.as_str()),
             }
         }
 

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -70,7 +70,6 @@ impl<T: TryInto<DeviceConfig, Error = DeviceError>> EnvBuilder<T> {
             }
         }
 
-        let config = self.fallback.try_into().unwrap();
-        Ok(config)
+        self.fallback.try_into()
     }
 }

--- a/src/config/find.rs
+++ b/src/config/find.rs
@@ -49,11 +49,10 @@ pub(crate) fn find_devices_in(
         );
     }
 
-    let config_count = config.cfgs.iter().fold(0, |acc, cfg| acc + cfg.count());
-    let mut found: Vec<DeviceFile> = Vec::with_capacity(config_count.into());
+    let mut found = Vec::new();
 
     for cfg in &config.cfgs {
-        'outer: for _ in 0..config_count {
+        'outer: for _ in 0..cfg.count() {
             for device in devices {
                 'inner: for dev_file in device.dev_files() {
                     if !cfg.fit(device.arch(), dev_file) {

--- a/src/config/find.rs
+++ b/src/config/find.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use super::DeviceConfig;
 use crate::device::{CoreIdx, CoreStatus, Device, DeviceFile};
 use crate::error::DeviceResult;
+use crate::DeviceError;
 
 pub(crate) struct DeviceWithStatus {
     pub device: Device,
@@ -79,8 +80,7 @@ pub(crate) fn find_devices_in(
                 }
             }
 
-            // TODO: we have to return error here
-            return Ok(vec![]);
+            return Err(DeviceError::device_not_found(cfg));
         }
     }
 

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -255,91 +255,91 @@ mod tests {
     }
 
     #[test]
-    fn test_config_from_named_text_repr() -> Result<(), nom::Err<()>> {
+    fn test_config_from_named_text_repr() -> eyre::Result<()> {
         assert!("0:".parse::<Config>().is_err());
         assert!(":0".parse::<Config>().is_err());
         assert!("0:0-1-".parse::<Config>().is_err());
         assert!("0:1-0".parse::<Config>().is_err());
 
         assert_eq!(
-            "0".parse::<Config>(),
-            Ok(Config::Named {
+            "0".parse::<Config>()?,
+            Config::Named {
                 device_id: 0,
                 core_range: CoreRange::All
-            })
+            }
         );
         assert_eq!(
-            "1".parse::<Config>(),
-            Ok(Config::Named {
+            "1".parse::<Config>()?,
+            Config::Named {
                 device_id: 1,
                 core_range: CoreRange::All
-            })
+            }
         );
         assert_eq!(
-            "0:0".parse::<Config>(),
-            Ok(Config::Named {
+            "0:0".parse::<Config>()?,
+            Config::Named {
                 device_id: 0,
                 core_range: CoreRange::Range((0, 0))
-            })
+            }
         );
         assert_eq!(
-            "0:1".parse::<Config>(),
-            Ok(Config::Named {
+            "0:1".parse::<Config>()?,
+            Config::Named {
                 device_id: 0,
                 core_range: CoreRange::Range((1, 1))
-            })
+            }
         );
         assert_eq!(
-            "1:1".parse::<Config>(),
-            Ok(Config::Named {
+            "1:1".parse::<Config>()?,
+            Config::Named {
                 device_id: 1,
                 core_range: CoreRange::Range((1, 1))
-            })
+            }
         );
         assert_eq!(
-            "0:0-1".parse::<Config>(),
-            Ok(Config::Named {
+            "0:0-1".parse::<Config>()?,
+            Config::Named {
                 device_id: 0,
                 core_range: CoreRange::Range((0, 1))
-            })
+            }
         );
 
         Ok(())
     }
 
     #[test]
-    fn test_config_from_unnamed_text_repr() -> Result<(), nom::Err<()>> {
+    fn test_config_from_unnamed_text_repr() -> eyre::Result<()> {
         assert!("warboy".parse::<Config>().is_err());
         assert!("warboy*".parse::<Config>().is_err());
         assert!("*1".parse::<Config>().is_err());
         assert!("some_npu*10".parse::<Config>().is_err());
         assert!("warboy(2*10".parse::<Config>().is_err());
         assert_eq!(
-            "warboy(1)*2".parse::<Config>(),
-            Ok(Config::Unnamed {
+            "warboy(1)*2".parse::<Config>()?,
+            Config::Unnamed {
                 arch: Arch::Warboy,
                 core_num: 1,
                 mode: DeviceMode::Single,
                 count: 2
-            })
+            }
         );
         assert_eq!(
-            "warboy(2)*4".parse::<Config>(),
-            Ok(Config::Unnamed {
+            "warboy(2)*4".parse::<Config>()?,
+            Config::Unnamed {
                 arch: Arch::Warboy,
                 core_num: 2,
                 mode: DeviceMode::Fusion,
                 count: 4
-            })
+            }
         );
         assert_eq!(
-            "warboy*12".parse::<Config>(),
-            Ok(Config::Unnamed {
+            "warboy*12".parse::<Config>()?,
+            Config::Unnamed {
                 arch: Arch::Warboy,
                 core_num: 1,
                 mode: DeviceMode::Single,
                 count: 12
-            })
+            }
         );
         // assert!("npu*10".parse::<Config>().is_ok());
 

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -62,25 +62,16 @@ impl Config {
             }
             Self::Unnamed {
                 arch: config_arch,
-                core_num: _,
                 mode,
-                count: _,
+                ..
             } => arch == *config_arch && device_file.mode() == *mode,
         }
     }
 
     pub(crate) fn count(&self) -> u8 {
         match self {
-            Self::Named {
-                device_id: _,
-                core_range: _,
-            } => 1,
-            Self::Unnamed {
-                arch: _,
-                core_num: _,
-                mode: _,
-                count,
-            } => *count,
+            Self::Named { .. } => 1,
+            Self::Unnamed { count, .. } => *count,
         }
     }
 }

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -340,4 +340,37 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_from_legacy_text_repr() -> eyre::Result<()> {
+        assert!("npu0pe".parse::<Config>().is_err());
+        assert!("npupe0".parse::<Config>().is_err());
+        assert!("npu0pe0,".parse::<Config>().is_err());
+
+        assert_eq!(
+            "npu1pe1".parse::<Config>()?,
+            Config::Named {
+                device_id: 1,
+                core_range: CoreRange::Range((1, 1))
+            }
+        );
+
+        assert_eq!(
+            "npu1pe0-1".parse::<Config>()?,
+            Config::Named {
+                device_id: 1,
+                core_range: CoreRange::Range((0, 1))
+            }
+        );
+
+        assert_eq!(
+            "npu1".parse::<Config>()?,
+            Config::Named {
+                device_id: 1,
+                core_range: CoreRange::All
+            }
+        );
+
+        Ok(())
+    }
 }

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
 

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -12,6 +12,7 @@ use nom::Parser;
 
 use crate::arch::Arch;
 use crate::device::{CoreRange, DeviceFile, DeviceMode};
+use crate::{DeviceError, DeviceResult};
 
 #[derive(Clone, Debug)]
 pub(crate) struct DeviceConfigInner {
@@ -19,7 +20,7 @@ pub(crate) struct DeviceConfigInner {
 }
 
 impl FromStr for DeviceConfigInner {
-    type Err = eyre::Error;
+    type Err = DeviceError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {
@@ -78,13 +79,9 @@ impl Config {
 }
 
 impl FromStr for Config {
-    type Err = eyre::Error;
+    type Err = DeviceError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        fn clone_at_err<E: Error>(e: E) -> eyre::Report {
-            eyre::eyre!("{}", e)
-        }
-
         fn digit_to_u8<'a>(
         ) -> impl FnMut(&'a str) -> nom::IResult<&'a str, u8, nom::error::Error<&'a str>> {
             map_res(digit1, |s: &str| s.parse::<u8>())
@@ -103,14 +100,14 @@ impl FromStr for Config {
         }
 
         // Try parsing a "npu0pe0" pattern. Note that "npu0" is also valid, which represents npu0 as MultiCore mode.
-        fn legacy_parser(s: &str) -> eyre::Result<Config> {
+        fn legacy_parser(s: &str) -> DeviceResult<Config> {
             let parser_id = preceded(tag("npu"), digit_to_u8());
             let parser_cores = map(opt(preceded(tag("pe"), parse_cores())), |c| {
                 c.unwrap_or(CoreRange::All)
             });
 
-            let (_, (device_id, core_range)) =
-                all_consuming(parser_id.and(parser_cores))(s).map_err(clone_at_err)?;
+            let (_, (device_id, core_range)) = all_consuming(parser_id.and(parser_cores))(s)
+                .map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
 
             Ok(Config::Named {
                 device_id,
@@ -119,13 +116,13 @@ impl FromStr for Config {
         }
 
         // Try parsing a "0:0" or "0:0-1" pattern. Note that "0" is also valid, which represents npu0 as MultiCore mode.
-        fn named_cfg_parser(s: &str) -> eyre::Result<Config> {
+        fn named_cfg_parser(s: &str) -> DeviceResult<Config> {
             let parser_cores = map(opt(preceded(tag(":"), parse_cores())), |c| {
                 c.unwrap_or(CoreRange::All)
             });
 
-            let (_, (device_id, core_range)) =
-                all_consuming(digit_to_u8().and(parser_cores))(s).map_err(clone_at_err)?;
+            let (_, (device_id, core_range)) = all_consuming(digit_to_u8().and(parser_cores))(s)
+                .map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
 
             Ok(Config::Named {
                 device_id,
@@ -134,7 +131,7 @@ impl FromStr for Config {
         }
 
         // Try parsing a "warboy(1)*1" pattern
-        fn unnamed_cfg_parser(s: &str) -> eyre::Result<Config> {
+        fn unnamed_cfg_parser(s: &str) -> DeviceResult<Config> {
             // Currently supports "warboy" only
             let parser_arch = map_res(tag("warboy"), |s: &str| s.parse::<Arch>());
             let parser_mode =
@@ -152,7 +149,7 @@ impl FromStr for Config {
             // Note: nom::sequence::tuple requires parsers to have equivalent signatures
             let (_, ((arch, (core_num, mode)), count)) =
                 all_consuming(parser_arch.and(parser_mode).and(parser_count))(s)
-                    .map_err(clone_at_err)?;
+                    .map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
 
             Ok(Config::Unnamed {
                 arch,
@@ -165,7 +162,6 @@ impl FromStr for Config {
         legacy_parser(s)
             .or_else(|_| named_cfg_parser(s))
             .or_else(|_| unnamed_cfg_parser(s))
-            .map_err(|_| eyre::eyre!("Failed to parse {}", s))
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -77,8 +77,8 @@ impl DeviceConfig {
         }
     }
 
-    /// Returns a DeviceConfig equivalent to the textual representation saved in an environment variable.
-    /// Returns error if the environment variable is empty or the syntax is not met.
+    /// Returns a builder struct to read config saved in an environment variable.
+    /// You can provide fallback options to the builder in case the envrionment variable is empty.
     pub fn from_env<K: ToString>(key: K) -> EnvBuilder<NotDetermined> {
         EnvBuilder::<NotDetermined>::from_env(key)
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@ use std::{ffi::OsStr, fmt::Display};
 
 pub use builder::DeviceConfigBuilder;
 pub(crate) use find::{expand_status, find_devices_in};
-use inner::DeviceConfigInner;
+use inner::Config;
 
 use self::builder::NotDetermined;
 use crate::{Arch, DeviceError};
@@ -31,7 +31,7 @@ use crate::{Arch, DeviceError};
 /// See also [struct `Device`][`Device`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct DeviceConfig {
-    pub(crate) inner: DeviceConfigInner,
+    pub(crate) inner: Config,
 }
 
 impl DeviceConfig {
@@ -47,7 +47,7 @@ impl DeviceConfig {
     pub fn from_env_with_key<S: AsRef<OsStr>>(key: S) -> Result<Self, DeviceError> {
         match std::env::var(key) {
             Ok(message) => Ok(Self {
-                inner: DeviceConfigInner::from_str(&message)
+                inner: Config::from_str(&message)
                     .map_err(|cause| DeviceError::ParseError { message, cause })?,
             }),
             Err(cause) => Err(DeviceError::EnvVarError { cause }),
@@ -70,7 +70,7 @@ impl FromStr for DeviceConfig {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {
-            inner: DeviceConfigInner::from_str(s)?,
+            inner: Config::from_str(s)?,
         })
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -259,7 +259,30 @@ mod tests {
         assert_eq!(found[2].filename(), "npu1pe0");
         assert_eq!(found[3].filename(), "npu1pe1");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_devices_with_comma_separated_failing_cases() -> eyre::Result<()> {
+        // test directory contains 2 warboy NPUs
+        let devices = list_devices_with("test_data/test-0/dev", "test_data/test-0/sys").await?;
+        let devices_with_statuses = expand_status(devices).await?;
+
         // test trivial failing cases
+        let config = "0:0,0:0".parse::<DeviceConfig>()?;
+        let found = find_devices_in(&config, &devices_with_statuses);
+        match found {
+            Ok(_) => panic!("looking for duplicate devices should fail"),
+            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
+        }
+
+        let config = "0:0-1,npu0pe0-1".parse::<DeviceConfig>()?;
+        let found = find_devices_in(&config, &devices_with_statuses);
+        match found {
+            Ok(_) => panic!("looking for duplicate devices should fail"),
+            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
+        }
+
         Ok(())
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod env;
 pub(crate) mod find;
 mod inner;
 
@@ -122,6 +123,14 @@ impl FromStr for DeviceConfig {
         Ok(Self {
             inner: DeviceConfigInner::from_str(s)?,
         })
+    }
+}
+
+impl<'a> TryFrom<&'a str> for DeviceConfig {
+    type Error = eyre::Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        DeviceConfig::from_str(value)
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -117,7 +117,7 @@ impl Default for DeviceConfig {
 }
 
 impl FromStr for DeviceConfig {
-    type Err = eyre::Error;
+    type Err = DeviceError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {
@@ -127,7 +127,7 @@ impl FromStr for DeviceConfig {
 }
 
 impl<'a> TryFrom<&'a str> for DeviceConfig {
-    type Error = eyre::Error;
+    type Error = DeviceError;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         DeviceConfig::from_str(value)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -33,14 +33,14 @@ use crate::{Arch, DeviceError};
 ///
 /// DeviceConfig supports textual representation, which is its equivalent string representation.
 /// One can obtain the corresponding DeviceConfig from the textual representation
-/// by using the FromStr trait, or by calling [`from_env_with_key`][`DeviceConfig::from_env_with_key`]
+/// by using the FromStr trait, or by calling [`from_env`][`DeviceConfig::from_env`]
 /// after setting an environment variable.
 ///
 /// ```rust
 /// use std::str::FromStr;
 /// use furiosa_device::DeviceConfig;
 ///
-/// let config = DeviceConfig::from_env_with_key("SOME_OTHER_ENV_KEY");
+/// let config = DeviceConfig::from_env("SOME_OTHER_ENV_KEY").build();
 /// let config = DeviceConfig::from_str("0:0,0:1"); // get config directly from a string literal
 /// ```
 ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,7 +28,45 @@ use crate::{Arch, DeviceError};
 /// DeviceConfig::warboy().fused().count(2);
 /// ```
 ///
-/// See also [struct `Device`][`Device`].
+/// # Textual Representation
+///
+/// DeviceConfig supports textual representation, which is its equivalent string representation.
+/// One can obtain the corresponding DeviceConfig from the textual representation
+/// by using the FromStr trait, or by calling [`from_env_with_key`][`DeviceConfig::from_env_with_key`]
+/// after setting an environment variable.
+///
+/// ```rust
+/// let config = DeviceConfig::from_env()?; // default key is "FURIOSA_DEVICES"
+/// let config = DeviceConfig::from_env_with_key("SOME_OTHER_ENV_KEY")?;
+/// let config = DeviceConfig::from_str("0:0,0:1")?; // get config directly from a string literal
+/// ```
+///
+/// The rules for textual representation are as follows:
+///
+/// ```bash
+/// # Using specific device names
+/// FURIOSA_DEVICES="0:0" # npu0pe0
+/// FURIOSA_DEVICES="0:0-1" # npu0pe0-1
+
+/// # Using device configs
+/// FURIOSA_DEVICES="warboy*2" # warboy multi core mode x 2
+/// FURIOSA_DEVICES="warboy(1)*2" # single pe x 2
+/// FURIOSA_DEVICES="warboy(2)*2" # 2-pe fusioned x 2
+
+/// # Using device configs with a random device
+/// # It can be commonly used because most of systems will have a single kind of NPUs.
+/// FURIOSA_DEVICES="npu(2)*2" # any 2-pe fusioned device x 2
+
+/// # When we use multiple models in a single application
+/// FURIOSA_DEVICES="APP1=warboy*2, APP2=warboy(2)*2" # Allow to specify two different device configurations for two applications 'APP1' and 'APP2'
+/// ```
+///
+/// You can also combine multiple string representations into one DeviceConfig,
+/// by separating them with commas.
+///
+/// ```bash
+/// FURIOSA_DEVICES="0:0,0:1" # npu0pe0, npu0pe1
+/// ```
 #[derive(Clone, Debug)]
 pub struct DeviceConfig {
     pub(crate) inner: DeviceConfigInner,
@@ -55,7 +93,7 @@ impl DeviceConfig {
     }
 
     pub fn from_env() -> Result<Self, DeviceError> {
-        Self::from_env_with_key("NPU_DEVNAME")
+        Self::from_env_with_key("FURIOSA_DEVICES")
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,36 +36,31 @@ use crate::{Arch, DeviceError};
 /// after setting an environment variable.
 ///
 /// ```rust
-/// let config = DeviceConfig::from_env()?; // default key is "FURIOSA_DEVICES"
-/// let config = DeviceConfig::from_env_with_key("SOME_OTHER_ENV_KEY")?;
-/// let config = DeviceConfig::from_str("0:0,0:1")?; // get config directly from a string literal
+/// use std::str::FromStr;
+/// use furiosa_device::DeviceConfig;
+///
+/// let config = DeviceConfig::from_env(); // default key is "FURIOSA_DEVICES"
+/// let config = DeviceConfig::from_env_with_key("SOME_OTHER_ENV_KEY");
+/// let config = DeviceConfig::from_str("0:0,0:1"); // get config directly from a string literal
 /// ```
 ///
 /// The rules for textual representation are as follows:
 ///
-/// ```bash
-/// # Using specific device names
-/// FURIOSA_DEVICES="0:0" # npu0pe0
-/// FURIOSA_DEVICES="0:0-1" # npu0pe0-1
-
-/// # Using device configs
-/// FURIOSA_DEVICES="warboy*2" # warboy multi core mode x 2
-/// FURIOSA_DEVICES="warboy(1)*2" # single pe x 2
-/// FURIOSA_DEVICES="warboy(2)*2" # 2-pe fusioned x 2
-
-/// # Using device configs with a random device
-/// # It can be commonly used because most of systems will have a single kind of NPUs.
-/// FURIOSA_DEVICES="npu(2)*2" # any 2-pe fusioned device x 2
-
-/// # When we use multiple models in a single application
-/// FURIOSA_DEVICES="APP1=warboy*2, APP2=warboy(2)*2" # Allow to specify two different device configurations for two applications 'APP1' and 'APP2'
-/// ```
+/// ```rust
+/// use std::str::FromStr;
+/// use furiosa_device::DeviceConfig;
 ///
-/// You can also combine multiple string representations into one DeviceConfig,
-/// by separating them with commas.
+/// // Using specific device names
+/// DeviceConfig::from_str("0:0"); // npu0pe0
+/// DeviceConfig::from_str("0:0-1"); // npu0pe0-1
 ///
-/// ```bash
-/// FURIOSA_DEVICES="0:0,0:1" # npu0pe0, npu0pe1
+/// // Using device configs
+/// DeviceConfig::from_str("warboy*2"); // warboy multi core mode x 2
+/// DeviceConfig::from_str("warboy(1)*2"); // single pe x 2
+/// DeviceConfig::from_str("warboy(2)*2"); // 2-pe fusioned x 2
+///
+/// // Combine multiple representations separated by commas
+/// DeviceConfig::from_str("0:0-1, 1:0-1"); // npu0pe0-1, npu1pe0-1
 /// ```
 #[derive(Clone, Debug)]
 pub struct DeviceConfig {
@@ -82,6 +77,8 @@ impl DeviceConfig {
         }
     }
 
+    /// Returns a DeviceConfig equivalent to the textual representation saved in an environment variable.
+    /// Fails if the environment variable is empty or if the syntax is not met.
     pub fn from_env_with_key<S: AsRef<OsStr>>(key: S) -> Result<Self, DeviceError> {
         match std::env::var(key) {
             Ok(message) => Ok(Self {
@@ -92,6 +89,9 @@ impl DeviceConfig {
         }
     }
 
+    /// Returns a DeviceConfig equivalent to the textual representation saved in an environment variable.
+    /// Fails if the environment variable is empty or if the syntax is not met.
+    /// This is equivalent to `DeviceConfig::from_env_with_key("FURIOSA_DEVICES")`.
     pub fn from_env() -> Result<Self, DeviceError> {
         Self::from_env_with_key("FURIOSA_DEVICES")
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,10 +84,10 @@ impl Display for DeviceConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{list::list_devices_with, DeviceResult};
+    use crate::list::list_devices_with;
 
     #[tokio::test]
-    async fn test_find_devices() -> DeviceResult<()> {
+    async fn test_find_devices() -> eyre::Result<()> {
         // test directory contains 2 warboy NPUs
         let devices = list_devices_with("test_data/test-0/dev", "test_data/test-0/sys").await?;
         let devices_with_statuses = expand_status(devices).await?;
@@ -122,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    fn test_config_symmetric_display() -> Result<(), nom::Err<()>> {
+    fn test_config_symmetric_display() -> eyre::Result<()> {
         assert_eq!("0".parse::<DeviceConfig>()?.to_string(), "0");
         assert_eq!("1".parse::<DeviceConfig>()?.to_string(), "1");
         assert_eq!("0:0".parse::<DeviceConfig>()?.to_string(), "0:0");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,9 +7,9 @@ use std::{ffi::OsStr, fmt::Display};
 
 pub use builder::DeviceConfigBuilder;
 pub(crate) use find::{expand_status, find_devices_in};
-use inner::Config;
 
 use self::builder::NotDetermined;
+use self::inner::DeviceConfigInner;
 use crate::{Arch, DeviceError};
 
 /// Describes a required set of devices for [`find_devices`][crate::find_devices].
@@ -29,9 +29,9 @@ use crate::{Arch, DeviceError};
 /// ```
 ///
 /// See also [struct `Device`][`Device`].
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct DeviceConfig {
-    pub(crate) inner: Config,
+    pub(crate) inner: DeviceConfigInner,
 }
 
 impl DeviceConfig {
@@ -47,7 +47,7 @@ impl DeviceConfig {
     pub fn from_env_with_key<S: AsRef<OsStr>>(key: S) -> Result<Self, DeviceError> {
         match std::env::var(key) {
             Ok(message) => Ok(Self {
-                inner: Config::from_str(&message)
+                inner: DeviceConfigInner::from_str(&message)
                     .map_err(|cause| DeviceError::ParseError { message, cause })?,
             }),
             Err(cause) => Err(DeviceError::EnvVarError { cause }),
@@ -70,7 +70,7 @@ impl FromStr for DeviceConfig {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {
-            inner: Config::from_str(s)?,
+            inner: DeviceConfigInner::from_str(s)?,
         })
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,7 +66,7 @@ impl Default for DeviceConfig {
 }
 
 impl FromStr for DeviceConfig {
-    type Err = nom::Err<()>;
+    type Err = eyre::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -174,4 +174,42 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_config_comma_separated() -> eyre::Result<()> {
+        let config = "0:0,0:1,0:0-1,warboy(1)*1,warboy(2)*2,npu0pe0".parse::<DeviceConfig>()?;
+
+        assert_eq!(
+            config.inner.cfgs,
+            vec![
+                "0:0".parse::<crate::config::inner::Config>()?,
+                "0:1".parse::<crate::config::inner::Config>()?,
+                "0:0-1".parse::<crate::config::inner::Config>()?,
+                "warboy(1)*1".parse::<crate::config::inner::Config>()?,
+                "warboy(2)*2".parse::<crate::config::inner::Config>()?,
+                "npu0pe0".parse::<crate::config::inner::Config>()?,
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_config_from_env() -> eyre::Result<()> {
+        let key = "ENV_KEY";
+        std::env::set_var(key, "0:0,0:1,0:0-1,warboy(1)*1,warboy(2)*2,npu0pe0");
+        let config = DeviceConfig::from_env(key).build()?;
+
+        assert_eq!(
+            config.inner.cfgs,
+            vec![
+                "0:0".parse::<crate::config::inner::Config>()?,
+                "0:1".parse::<crate::config::inner::Config>()?,
+                "0:0-1".parse::<crate::config::inner::Config>()?,
+                "warboy(1)*1".parse::<crate::config::inner::Config>()?,
+                "warboy(2)*2".parse::<crate::config::inner::Config>()?,
+                "npu0pe0".parse::<crate::config::inner::Config>()?,
+            ]
+        );
+        Ok(())
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,8 +9,9 @@ use std::str::FromStr;
 pub use builder::DeviceConfigBuilder;
 pub(crate) use find::{expand_status, find_devices_in};
 
+use self::builder::NotDetermined;
+pub use self::env::EnvBuilder;
 use self::inner::DeviceConfigInner;
-use self::{builder::NotDetermined, env::EnvBuilder};
 use crate::{Arch, DeviceError};
 
 /// Describes a required set of devices for [`find_devices`][crate::find_devices].

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,6 @@ use crate::{Arch, DeviceError};
 /// use std::str::FromStr;
 /// use furiosa_device::DeviceConfig;
 ///
-/// let config = DeviceConfig::from_env(); // default key is "FURIOSA_DEVICES"
 /// let config = DeviceConfig::from_env_with_key("SOME_OTHER_ENV_KEY");
 /// let config = DeviceConfig::from_str("0:0,0:1"); // get config directly from a string literal
 /// ```

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,7 +56,7 @@ use crate::{Arch, DeviceError};
 /// DeviceConfig::from_str("0:0-1"); // npu0pe0-1
 ///
 /// // Using device configs
-/// DeviceConfig::from_str("warboy*2"); // warboy multi core mode x 2
+/// DeviceConfig::from_str("warboy*2"); // single pe x 2 (equivalent to "warboy(1)*2")
 /// DeviceConfig::from_str("warboy(1)*2"); // single pe x 2
 /// DeviceConfig::from_str("warboy(2)*2"); // 2-pe fusioned x 2
 ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -137,8 +137,11 @@ mod tests {
 
         // looking for 5 different cores should fail
         let config = DeviceConfig::warboy().single().count(5);
-        let found = find_devices_in(&config, &devices_with_statuses)?;
-        assert_eq!(found, vec![]);
+        let found = find_devices_in(&config, &devices_with_statuses);
+        match found {
+            Ok(_) => panic!("looking for 5 different cores should fail"),
+            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
+        }
 
         // try lookup 2 different fused cores
         let config = DeviceConfig::warboy().fused().count(2);
@@ -149,8 +152,11 @@ mod tests {
 
         // looking for 3 different fused cores should fail
         let config = DeviceConfig::warboy().fused().count(3);
-        let found = find_devices_in(&config, &devices_with_statuses)?;
-        assert_eq!(found, vec![]);
+        let found = find_devices_in(&config, &devices_with_statuses);
+        match found {
+            Ok(_) => panic!("looking for 3 different fused cores should fail"),
+            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
+        }
 
         Ok(())
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -378,7 +378,7 @@ pub(crate) type CoreIdx = u8;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum CoreRange {
-    All,
+    All, // TODO: rename this to MultiCore
     Range((u8, u8)),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ pub enum DeviceError {
     #[error("Failed to parse given message {message}: {cause}")]
     ParseError {
         message: String,
-        cause: nom::Err<()>,
+        cause: eyre::Error,
     },
     #[error("Coud not retrieve the environment variable")]
     EnvVarError { cause: std::env::VarError },

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,13 @@ pub enum DeviceError {
     HwmonError { device_index: u8, cause: HwmonError },
     #[error("Unexpected value: {message}")]
     UnexpectedValue { message: String },
+    #[error("Failed to parse given message {message}: {cause}")]
+    ParseError {
+        message: String,
+        cause: nom::Err<()>,
+    },
+    #[error("Coud not retrieve the environment variable")]
+    EnvVarError { cause: std::env::VarError },
 }
 
 impl DeviceError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,10 +27,7 @@ pub enum DeviceError {
     #[error("Unexpected value: {message}")]
     UnexpectedValue { message: String },
     #[error("Failed to parse given message {message}: {cause}")]
-    ParseError {
-        message: String,
-        cause: eyre::Error,
-    },
+    ParseError { message: String, cause: eyre::Error },
     #[error("Coud not retrieve the environment variable")]
     EnvVarError { cause: std::env::VarError },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,12 @@ pub enum DeviceError {
 }
 
 impl DeviceError {
+    pub(crate) fn device_not_found<F: Display>(device: F) -> DeviceError {
+        DeviceError::DeviceNotFound {
+            name: device.to_string(),
+        }
+    }
+
     pub(crate) fn file_not_found<F: Display>(file: F) -> DeviceError {
         use io::ErrorKind;
         IoError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,9 +32,9 @@ pub enum DeviceError {
 }
 
 impl DeviceError {
-    pub(crate) fn device_not_found<F: Display>(device: F) -> DeviceError {
+    pub(crate) fn device_not_found<D: Display>(name: D) -> DeviceError {
         DeviceError::DeviceNotFound {
-            name: device.to_string(),
+            name: name.to_string(),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,9 +27,7 @@ pub enum DeviceError {
     #[error("Unexpected value: {message}")]
     UnexpectedValue { message: String },
     #[error("Failed to parse given message {message}: {cause}")]
-    ParseError { message: String, cause: eyre::Error },
-    #[error("Coud not retrieve the environment variable")]
-    EnvVarError { cause: std::env::VarError },
+    ParseError { message: String, cause: String },
 }
 
 impl DeviceError {
@@ -68,6 +66,13 @@ impl DeviceError {
     pub(crate) fn unexpected_value<S: ToString>(message: S) -> DeviceError {
         UnexpectedValue {
             message: message.to_string(),
+        }
+    }
+
+    pub(crate) fn parse_error<S: ToString, C: ToString>(message: S, cause: C) -> DeviceError {
+        DeviceError::ParseError {
+            message: message.to_string(),
+            cause: cause.to_string(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::Display;
 use std::io;
 
@@ -84,5 +85,11 @@ impl From<io::Error> for DeviceError {
         } else {
             Self::IoError { cause: e }
         }
+    }
+}
+
+impl From<Infallible> for DeviceError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 
 pub use crate::arch::Arch;
 use crate::config::{expand_status, find_devices_in};
-pub use crate::config::{DeviceConfig, DeviceConfigBuilder};
+pub use crate::config::{DeviceConfig, DeviceConfigBuilder, EnvBuilder};
 pub use crate::device::{CoreRange, CoreStatus, Device, DeviceFile, DeviceMode};
 pub use crate::error::{DeviceError, DeviceResult};
 use crate::list::list_devices_with;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 
 // Allows displaying feature flags in the documentation.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![feature(associated_type_bounds)]
 
 pub use crate::arch::Arch;
 use crate::config::{expand_status, find_devices_in};


### PR DESCRIPTION
fixes #59
depends on #61

## Major Changes
- DeviceConfig now parses comma-separated syntaxes (e.g., `0:0,0:1` or `warboy(1)*2,warboy(2)*1` ..)
- DeviceConfig now supports `npu0pe0`-like textual representations
- Introduce `DeviceConfig::from_env()` and related `EnvBuilder`
  - One can use it like `DeviceConfig::from_env("FURIOSA_DEVICES").or_env("NPU_DEVNAME").or_default().build()?`
- Add documentations for `DeviceConfig`'s textual representation

## Minor Changes
- Add eyre as dev-dependency for better test cases
- Update toolchain to nightly
- Add rustfmt.toml