### PR TITLE
Fix find_device_files

### DIFF
--- a/bindings/python/tests/test_fn.py
+++ b/bindings/python/tests/test_fn.py
@@ -46,8 +46,12 @@ async def test_find_device_files_single_pe():
     pe0 = dev_name + "pe0"
     pe1 = dev_name + "pe1"
     config = DeviceConfig.from_str(f"{pe0},{pe1}")
-    fd = os.open(f"/dev/{pe0}", os.O_RDWR)
     devices = await find_device_files(config)
+    assert len(devices) == 2
+    fd = os.open(f"/dev/{pe0}", os.O_RDWR)
+    # Make sure if another pe is still available
+    # Please refer to https://github.com/furiosa-ai/device-api/issues/95.
+    devices = await find_device_files(DeviceConfig.from_str(f"{pe1}"))
     os.close(fd)
     assert len(devices) == 1
     assert devices[0].filename() == pe1

--- a/bindings/python/tests/test_fn.py
+++ b/bindings/python/tests/test_fn.py
@@ -46,9 +46,8 @@ async def test_find_device_files_err():
     config = DeviceConfig.from_str(dev_name)
     fd = os.open(f"/dev/{dev_name}", os.O_RDWR)
     try:
-        _ = await find_device_files(config)
-    except Exception as e:
-        assert str(e).endswith("found but still in use")
+        with pytest.raises(Exception, match=r"found but still in use$"):
+            _ = await find_device_files(config)
     finally:
         os.close(fd)
 

--- a/bindings/python/tests/test_fn.py
+++ b/bindings/python/tests/test_fn.py
@@ -41,6 +41,19 @@ async def test_find_device_files():
 
 
 @pytest.mark.asyncio
+async def test_find_device_files_single_pe():
+    dev_name = get_first_device_name("/dev/npu*")
+    pe0 = dev_name + "pe0"
+    pe1 = dev_name + "pe1"
+    config = DeviceConfig.from_str(f"{pe0},{pe1}")
+    fd = os.open(f"/dev/{pe0}", os.O_RDWR)
+    devices = await find_device_files(config)
+    os.close(fd)
+    assert len(devices) == 1
+    assert devices[0].filename() == pe1
+
+
+@pytest.mark.asyncio
 async def test_find_device_files_err():
     dev_name = get_first_device_name("/dev/npu*pe0")
     config = DeviceConfig.from_str(dev_name)

--- a/bindings/python/tests/test_fn.py
+++ b/bindings/python/tests/test_fn.py
@@ -1,4 +1,5 @@
 import glob
+import os
 
 import pytest
 from furiosa_native_device import (
@@ -22,12 +23,14 @@ async def test_list_devices():
     devices = await list_devices()
     assert devices[0].name() == dev_name
 
+
 @pytest.mark.asyncio
 async def test_get_device():
     dev_name = get_first_device_name("/dev/npu*")
-    dev_idx = int(dev_name.replace('npu', ''))
+    dev_idx = int(dev_name.replace("npu", ""))
     device = await get_device(dev_idx)
     assert device.name() == dev_name
+
 
 @pytest.mark.asyncio
 async def test_find_device_files():
@@ -35,6 +38,19 @@ async def test_find_device_files():
     config = DeviceConfig(arch=Arch.Warboy, mode=DeviceMode.Fusion, count=1)
     devices = await find_device_files(config)
     assert devices[0].filename() == dev_name
+
+
+@pytest.mark.asyncio
+async def test_find_device_files_err():
+    dev_name = get_first_device_name("/dev/npu*pe0")
+    config = DeviceConfig.from_str(dev_name)
+    fd = os.open(f"/dev/{dev_name}", os.O_RDWR)
+    try:
+        _ = await find_device_files(config)
+    except Exception as e:
+        assert str(e).endswith("found but still in use")
+    finally:
+        os.close(fd)
 
 
 @pytest.mark.asyncio

--- a/bindings/python/tests/test_fn_sync.py
+++ b/bindings/python/tests/test_fn_sync.py
@@ -40,8 +40,12 @@ def test_find_device_files_single_pe():
     pe0 = dev_name + "pe0"
     pe1 = dev_name + "pe1"
     config = DeviceConfig.from_str(f"{pe0},{pe1}")
-    fd = os.open(f"/dev/{pe0}", os.O_RDWR)
     devices = find_device_files(config)
+    assert len(devices) == 2
+    fd = os.open(f"/dev/{pe0}", os.O_RDWR)
+    # Make sure if another pe is still available
+    # Please refer to https://github.com/furiosa-ai/device-api/issues/95.
+    devices = find_device_files(DeviceConfig.from_str(f"{pe1}"))
     os.close(fd)
     assert len(devices) == 1
     assert devices[0].filename() == pe1

--- a/bindings/python/tests/test_fn_sync.py
+++ b/bindings/python/tests/test_fn_sync.py
@@ -35,6 +35,18 @@ def test_find_device_files():
     assert devices[0].filename() == dev_name
 
 
+def test_find_device_files_single_pe():
+    dev_name = get_first_device_name("/dev/npu*")
+    pe0 = dev_name + "pe0"
+    pe1 = dev_name + "pe1"
+    config = DeviceConfig.from_str(f"{pe0},{pe1}")
+    fd = os.open(f"/dev/{pe0}", os.O_RDWR)
+    devices = find_device_files(config)
+    os.close(fd)
+    assert len(devices) == 1
+    assert devices[0].filename() == pe1
+
+
 def test_find_device_files_err():
     dev_name = get_first_device_name("/dev/npu*pe0")
     config = DeviceConfig.from_str(dev_name)

--- a/bindings/python/tests/test_fn_sync.py
+++ b/bindings/python/tests/test_fn_sync.py
@@ -1,6 +1,7 @@
 import glob
 import os
 
+import pytest
 from furiosa_native_device import Arch, DeviceConfig, DeviceMode
 from furiosa_native_device.sync import (
     find_device_files,
@@ -39,9 +40,8 @@ def test_find_device_files_err():
     config = DeviceConfig.from_str(dev_name)
     fd = os.open(f"/dev/{dev_name}", os.O_RDWR)
     try:
-        _ = find_device_files(config)
-    except Exception as e:
-        assert str(e).endswith("found but still in use")
+        with pytest.raises(Exception, match=r"found but still in use$"):
+            _ = find_device_files(config)
     finally:
         os.close(fd)
 

--- a/bindings/python/tests/test_fn_sync.py
+++ b/bindings/python/tests/test_fn_sync.py
@@ -1,7 +1,13 @@
 import glob
+import os
 
 from furiosa_native_device import Arch, DeviceConfig, DeviceMode
-from furiosa_native_device.sync import find_device_files, get_device, get_device_file, list_devices
+from furiosa_native_device.sync import (
+    find_device_files,
+    get_device,
+    get_device_file,
+    list_devices,
+)
 
 
 def get_first_device_name(pattern):
@@ -13,17 +19,31 @@ def test_list_devices():
     devices = list_devices()
     assert devices[0].name() == dev_name
 
+
 def test_get_device():
     dev_name = get_first_device_name("/dev/npu*")
-    dev_idx = int(dev_name.replace('npu', ''))
+    dev_idx = int(dev_name.replace("npu", ""))
     device = get_device(dev_idx)
     assert device.name() == dev_name
+
 
 def test_find_device_files():
     dev_name = get_first_device_name("/dev/npu*pe0-1")
     config = DeviceConfig(arch=Arch.Warboy, mode=DeviceMode.Fusion, count=1)
     devices = find_device_files(config)
     assert devices[0].filename() == dev_name
+
+
+def test_find_device_files_err():
+    dev_name = get_first_device_name("/dev/npu*pe0")
+    config = DeviceConfig.from_str(dev_name)
+    fd = os.open(f"/dev/{dev_name}", os.O_RDWR)
+    try:
+        _ = find_device_files(config)
+    except Exception as e:
+        assert str(e).endswith("found but still in use")
+    finally:
+        os.close(fd)
 
 
 def test_get_device_file():

--- a/device-api/src/blocking.rs
+++ b/device-api/src/blocking.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use crate::config::find::DeviceWithStatus;
 use crate::devfs::is_character_device;
 use crate::device::{CoreIdx, CoreStatus, DeviceInfo};
-use crate::hwmon;
 use crate::list::{collect_devices, filter_dev_files, DevFile};
 use crate::status::DeviceStatus;
 use crate::sysfs::npu_mgmt;
@@ -16,6 +15,7 @@ use crate::sysfs::npu_mgmt::MgmtFile;
 use crate::{
     devfs, find_device_files_in, Device, DeviceConfig, DeviceError, DeviceFile, DeviceResult,
 };
+use crate::{hwmon, DeviceMode};
 
 /// List all Furiosa NPU devices in the system.
 pub fn list_devices() -> DeviceResult<Vec<Device>> {
@@ -164,6 +164,9 @@ pub fn get_status_all(device: &Device) -> DeviceResult<HashMap<CoreIdx, CoreStat
     let mut status_map = device.new_status_map();
 
     for file in &device.dev_files {
+        if file.mode() != DeviceMode::Single {
+            continue;
+        }
         if get_device_status(&file.path)? == DeviceStatus::Occupied {
             for core in device
                 .cores()

--- a/device-api/src/blocking.rs
+++ b/device-api/src/blocking.rs
@@ -205,12 +205,14 @@ mod tests {
 
         // try lookup 4 different single cores
         let config = DeviceConfig::warboy().single().count(4);
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
         // looking for 5 different cores should fail
         let config = DeviceConfig::warboy().single().count(5);
@@ -220,14 +222,16 @@ mod tests {
             Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
         }
 
-        // try lookup 2 different fused cores
+        // // try lookup 2 different fused cores
         let config = DeviceConfig::warboy().fused().count(2);
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0].filename(), "npu0pe0-1");
-        assert_eq!(found[1].filename(), "npu1pe0-1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 2);
+        assert!(found_device_file_names.contains(&"npu0pe0-1"));
+        assert!(found_device_file_names.contains(&"npu1pe0-1"));
 
-        // looking for 3 different fused cores should fail
+        // // looking for 3 different fused cores should fail
         let config = DeviceConfig::warboy().fused().count(3);
         let found = find_device_files_in(&config, &devices_with_statuses);
         match found {

--- a/device-api/src/blocking.rs
+++ b/device-api/src/blocking.rs
@@ -206,13 +206,13 @@ mod tests {
         // try lookup 4 different single cores
         let config = DeviceConfig::warboy().single().count(4);
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         // looking for 5 different cores should fail
         let config = DeviceConfig::warboy().single().count(5);
@@ -225,11 +225,10 @@ mod tests {
         // // try lookup 2 different fused cores
         let config = DeviceConfig::warboy().fused().count(2);
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 2);
-        assert!(found_device_file_names.contains(&"npu0pe0-1"));
-        assert!(found_device_file_names.contains(&"npu1pe0-1"));
+        found_device_file_names.sort();
+        assert_eq!(found_device_file_names, &["npu0pe0-1", "npu1pe0-1"],);
 
         // // looking for 3 different fused cores should fail
         let config = DeviceConfig::warboy().fused().count(3);

--- a/device-api/src/config/find.rs
+++ b/device-api/src/config/find.rs
@@ -72,9 +72,9 @@ pub(crate) fn find_device_files_in(
     }
 
     let available_device_files = fit_device_files
-        .iter()
-        .filter(|(_, status)| **status == CoreStatus::Available)
-        .map(|(dev_file, _)| dev_file.clone())
+        .into_iter()
+        .filter(|(_, status)| *status == CoreStatus::Available)
+        .map(|(dev_file, _)| dev_file)
         .collect::<Vec<DeviceFile>>();
     if available_device_files.is_empty() {
         return Err(DeviceError::device_busy(config));

--- a/device-api/src/config/find.rs
+++ b/device-api/src/config/find.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Deref;
 
 use super::inner::Count;
@@ -36,64 +36,49 @@ pub(crate) fn find_device_files_in(
     devices: &[DeviceWithStatus],
 ) -> DeviceResult<Vec<DeviceFile>> {
     let config = &config.inner;
-    let mut allocated: HashMap<u8, HashSet<u8>> = HashMap::with_capacity(devices.len());
-
-    for device in devices {
-        allocated.insert(
-            device.device_index(),
-            device
-                .statuses
-                .iter()
-                .filter(|(_, status)| **status != CoreStatus::Available)
-                .map(|(core, _)| *core)
-                .collect(),
-        );
-    }
-
-    let mut found = Vec::new();
-
+    let mut fit_device_files: HashMap<DeviceFile, CoreStatus> = HashMap::new();
     for cfg in &config.cfgs {
-        let count = cfg.count();
-        let limit = match count {
-            Count::Finite(c) => c,
-            Count::All => 255, // make the loop simple by choosing a large enough number
-        };
-        'outer: for _ in 0..limit {
-            for device in devices {
-                'inner: for dev_file in device.dev_files() {
-                    if !cfg.fit(device.arch(), dev_file) {
-                        continue 'inner;
-                    }
-
-                    let used = allocated.get_mut(&device.device_index()).unwrap();
-
-                    for core in used.iter() {
-                        if dev_file.core_range().contains(core) {
-                            continue 'inner;
-                        }
-                    }
-
-                    // this dev_file is suitable
-                    found.push(dev_file.clone());
-                    used.extend(
-                        device
-                            .cores()
-                            .iter()
-                            .filter(|idx| dev_file.core_range().contains(idx)),
-                    );
-                    continue 'outer;
+        let mut found = 0;
+        for device in devices {
+            for dev_file in device.dev_files() {
+                if !cfg.fit(device.arch(), dev_file) {
+                    continue;
                 }
+                let core_idxes: Vec<&CoreIdx> = device
+                    .cores()
+                    .iter()
+                    .filter(|c| dev_file.core_range.contains(c))
+                    .collect();
+                let status = if core_idxes
+                    .iter()
+                    .all(|c| *device.statuses.get(c).unwrap() == CoreStatus::Available)
+                {
+                    CoreStatus::Available
+                } else {
+                    CoreStatus::Unavailable
+                };
+                fit_device_files.insert(dev_file.clone(), status);
+                found += 1;
             }
-
-            // Device not found
-            match count {
-                Count::All => break 'outer,
-                Count::Finite(_) => {
+        }
+        match cfg.count() {
+            Count::Finite(n) => {
+                if n > found {
                     return Err(DeviceError::device_not_found(cfg));
                 }
             }
-        }
+            Count::All => (),
+        };
     }
 
-    Ok(found)
+    let available_device_files = fit_device_files
+        .iter()
+        .filter(|(_, status)| **status == CoreStatus::Available)
+        .map(|(dev_file, _)| dev_file.clone())
+        .collect::<Vec<DeviceFile>>();
+    if available_device_files.is_empty() {
+        return Err(DeviceError::device_busy(config));
+    }
+
+    Ok(available_device_files)
 }

--- a/device-api/src/config/mod.rs
+++ b/device-api/src/config/mod.rs
@@ -148,24 +148,24 @@ mod tests {
         // try lookup 4 different single cores
         let config = DeviceConfig::warboy().single().count(4);
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         // try lookup all single cores
         let config = DeviceConfig::warboy().single().all();
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         // // looking for 5 different cores should fail
         let config = DeviceConfig::warboy().single().count(5);
@@ -178,20 +178,18 @@ mod tests {
         // // try lookup 2 different fused cores
         let config = DeviceConfig::warboy().fused().count(2);
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 2);
-        assert!(found_device_file_names.contains(&"npu0pe0-1"));
-        assert!(found_device_file_names.contains(&"npu1pe0-1"));
+        found_device_file_names.sort();
+        assert_eq!(found_device_file_names, &["npu0pe0-1", "npu1pe0-1"],);
 
         // // try lookup all fused cores
         let config = DeviceConfig::warboy().fused().all();
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 2);
-        assert!(found_device_file_names.contains(&"npu0pe0-1"));
-        assert!(found_device_file_names.contains(&"npu1pe0-1"));
+        found_device_file_names.sort();
+        assert_eq!(found_device_file_names, &["npu0pe0-1", "npu1pe0-1"],);
 
         // // looking for 3 different fused cores should fail
         let config = DeviceConfig::warboy().fused().count(3);
@@ -280,43 +278,43 @@ mod tests {
         // try lookup with various valid configs
         let config = "npu:0:0,npu:0:1,npu:1:0,npu:1:1".parse::<DeviceConfig>()?;
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         let config = "npu:0:0,npu0pe1,npu:1:0,npu1pe1".parse::<DeviceConfig>()?;
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         let config = "warboy(1)*1,warboy(1)*1,warboy(1)*1,warboy(1)*1".parse::<DeviceConfig>()?;
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         let config = "npu:0:0,npu:0:1,warboy(1)*2".parse::<DeviceConfig>()?;
         let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
-        let found_device_file_names: Vec<&str> =
+        let mut found_device_file_names: Vec<&str> =
             found_device_files.iter().map(|f| f.filename()).collect();
-        assert_eq!(found_device_files.len(), 4);
-        assert!(found_device_file_names.contains(&"npu0pe0"));
-        assert!(found_device_file_names.contains(&"npu0pe1"));
-        assert!(found_device_file_names.contains(&"npu1pe0"));
-        assert!(found_device_file_names.contains(&"npu1pe1"));
+        found_device_file_names.sort();
+        assert_eq!(
+            found_device_file_names,
+            &["npu0pe0", "npu0pe1", "npu1pe0", "npu1pe1"],
+        );
 
         Ok(())
     }

--- a/device-api/src/config/mod.rs
+++ b/device-api/src/config/mod.rs
@@ -147,23 +147,27 @@ mod tests {
 
         // try lookup 4 different single cores
         let config = DeviceConfig::warboy().single().count(4);
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
         // try lookup all single cores
         let config = DeviceConfig::warboy().single().all();
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
-        // looking for 5 different cores should fail
+        // // looking for 5 different cores should fail
         let config = DeviceConfig::warboy().single().count(5);
         let found = find_device_files_in(&config, &devices_with_statuses);
         match found {
@@ -171,21 +175,25 @@ mod tests {
             Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
         }
 
-        // try lookup 2 different fused cores
+        // // try lookup 2 different fused cores
         let config = DeviceConfig::warboy().fused().count(2);
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0].filename(), "npu0pe0-1");
-        assert_eq!(found[1].filename(), "npu1pe0-1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 2);
+        assert!(found_device_file_names.contains(&"npu0pe0-1"));
+        assert!(found_device_file_names.contains(&"npu1pe0-1"));
 
-        // try lookup all fused cores
+        // // try lookup all fused cores
         let config = DeviceConfig::warboy().fused().all();
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0].filename(), "npu0pe0-1");
-        assert_eq!(found[1].filename(), "npu1pe0-1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 2);
+        assert!(found_device_file_names.contains(&"npu0pe0-1"));
+        assert!(found_device_file_names.contains(&"npu1pe0-1"));
 
-        // looking for 3 different fused cores should fail
+        // // looking for 3 different fused cores should fail
         let config = DeviceConfig::warboy().fused().count(3);
         let found = find_device_files_in(&config, &devices_with_statuses);
         match found {
@@ -271,59 +279,81 @@ mod tests {
 
         // try lookup with various valid configs
         let config = "npu:0:0,npu:0:1,npu:1:0,npu:1:1".parse::<DeviceConfig>()?;
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
         let config = "npu:0:0,npu0pe1,npu:1:0,npu1pe1".parse::<DeviceConfig>()?;
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
         let config = "warboy(1)*1,warboy(1)*1,warboy(1)*1,warboy(1)*1".parse::<DeviceConfig>()?;
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
         let config = "npu:0:0,npu:0:1,warboy(1)*2".parse::<DeviceConfig>()?;
-        let found = find_device_files_in(&config, &devices_with_statuses)?;
-        assert_eq!(found.len(), 4);
-        assert_eq!(found[0].filename(), "npu0pe0");
-        assert_eq!(found[1].filename(), "npu0pe1");
-        assert_eq!(found[2].filename(), "npu1pe0");
-        assert_eq!(found[3].filename(), "npu1pe1");
+        let found_device_files = find_device_files_in(&config, &devices_with_statuses)?;
+        let found_device_file_names: Vec<&str> =
+            found_device_files.iter().map(|f| f.filename()).collect();
+        assert_eq!(found_device_files.len(), 4);
+        assert!(found_device_file_names.contains(&"npu0pe0"));
+        assert!(found_device_file_names.contains(&"npu0pe1"));
+        assert!(found_device_file_names.contains(&"npu1pe0"));
+        assert!(found_device_file_names.contains(&"npu1pe1"));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_find_device_files_with_comma_separated_failing_cases() -> eyre::Result<()> {
+    async fn test_find_device_files_with_duplicate_config() -> eyre::Result<()> {
+        // test directory contains 2 warboy NPUs
+        let devices =
+            list_devices_with("../test_data/test-0/dev", "../test_data/test-0/sys").await?;
+        let devices_with_statuses = expand_status(devices).await?;
+
+        // test duplicate configs
+        let config = "npu:0:0,npu:0:0".parse::<DeviceConfig>()?;
+        let found = find_device_files_in(&config, &devices_with_statuses)?;
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].filename(), "npu0pe0");
+
+        let config = "npu:0:0-1,npu0pe0-1".parse::<DeviceConfig>()?;
+        let found = find_device_files_in(&config, &devices_with_statuses)?;
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].filename(), "npu0pe0-1");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_device_files_with_failing_cases() -> eyre::Result<()> {
         // test directory contains 2 warboy NPUs
         let devices =
             list_devices_with("../test_data/test-0/dev", "../test_data/test-0/sys").await?;
         let devices_with_statuses = expand_status(devices).await?;
 
         // test trivial failing cases
-        let config = "npu:0:0,npu:0:0".parse::<DeviceConfig>()?;
+        let config = "npu:2:0".parse::<DeviceConfig>()?;
         let found = find_device_files_in(&config, &devices_with_statuses);
         match found {
-            Ok(_) => panic!("looking for duplicate devices should fail"),
-            Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
-        }
-
-        let config = "npu:0:0-1,npu0pe0-1".parse::<DeviceConfig>()?;
-        let found = find_device_files_in(&config, &devices_with_statuses);
-        match found {
-            Ok(_) => panic!("looking for duplicate devices should fail"),
+            Ok(_) => panic!("looking for not exist device should fail"),
             Err(e) => assert!(matches!(e, DeviceError::DeviceNotFound { .. })),
         }
 

--- a/device-api/src/device.rs
+++ b/device-api/src/device.rs
@@ -223,6 +223,10 @@ impl Device {
     /// Examine a specific core of the device, whether it is available or not.
     pub async fn get_status_core(&self, core: CoreIdx) -> DeviceResult<CoreStatus> {
         for file in &self.dev_files {
+            // get status of the exact core
+            if file.mode() != DeviceMode::Single {
+                continue;
+            }
             if (file.core_range().contains(&core))
                 && get_device_status(&file.path).await? == DeviceStatus::Occupied
             {

--- a/device-api/src/device.rs
+++ b/device-api/src/device.rs
@@ -487,7 +487,7 @@ impl TryFrom<(u8, u8)> for CoreRange {
 }
 
 /// An abstraction for a device file and its mode.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct DeviceFile {
     pub(crate) device_index: u8,
     pub(crate) core_range: CoreRange,
@@ -565,7 +565,7 @@ impl TryFrom<&PathBuf> for DeviceFile {
 }
 
 /// Enum for NPU's operating mode.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, enum_utils::FromStr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, enum_utils::FromStr)]
 #[enumeration(case_insensitive)]
 pub enum DeviceMode {
     Single,

--- a/device-api/src/error.rs
+++ b/device-api/src/error.rs
@@ -16,6 +16,8 @@ pub type DeviceResult<T> = Result<T, DeviceError>;
 pub enum DeviceError {
     #[error("Device {name} not found")]
     DeviceNotFound { name: String },
+    #[error("Device {name} found but still in use")]
+    DeviceBusy { name: String },
     #[error("IoError: {cause}")]
     IoError { cause: io::Error },
     #[error("PermissionDenied: {cause}")]
@@ -37,6 +39,12 @@ pub enum DeviceError {
 impl DeviceError {
     pub(crate) fn device_not_found<D: Display>(name: D) -> DeviceError {
         DeviceError::DeviceNotFound {
+            name: name.to_string(),
+        }
+    }
+
+    pub(crate) fn device_busy<D: Display>(name: D) -> DeviceError {
+        DeviceError::DeviceBusy {
             name: name.to_string(),
         }
     }


### PR DESCRIPTION
Resolve #93.
- Change the logic of `find_device_files_in` function
    - Find all fit device_files, then filter only the available
- Add tests
    - For DeviceBusy error, it is hard to reproduce in rust. So I add a test at python.