### PR TITLE
disable proc test on non-linux platform

### DIFF
--- a/device-api/src/proc.rs
+++ b/device-api/src/proc.rs
@@ -102,6 +102,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn read_cmdline_test() {
         let my_pid = std::process::id();
         let res = read_cmdline(my_pid);


### PR DESCRIPTION
disable proc test which cannot be run on mac on non-linux platform