### PR TITLE
Remove deprecated enums and re-design DeviceConfig

### DIFF
--- a/bindings/python/src/config/mod.rs
+++ b/bindings/python/src/config/mod.rs
@@ -12,16 +12,16 @@ use crate::errors::to_py_err;
 ///
 /// # Examples
 /// ```python
-/// from furiosa_device import Arch, DeviceConfig, DeviceMode
+/// from furiosa_device import Arch, DeviceConfig
 ///
-/// # 1 core
+/// # 1 core Warboy
 /// config = DeviceConfig(arch=Arch.Warboy)
 ///
-/// # 1 core x 2
+/// # 1 core Warboy x 2
 /// config = DeviceConfig(arch=Arch.Warboy, count=2)
 ///
-/// # Fused 2 cores x 2
-/// config = DeviceConfig(arch=Arch.Warboy, cores=2, count=2)
+/// # Fused 2 cores RNGD x 2
+/// config = DeviceConfig(arch=Arch.RNGD, cores=2, count=2)
 /// ```
 ///
 /// # Textual Representation
@@ -33,8 +33,8 @@ use crate::errors::to_py_err;
 /// ```python
 /// from furiosa_device import DeviceConfig
 ///
-/// config = DeviceConfig.from_env("SOME_OTHER_ENV_KEY")
-/// config = DeviceConfig.from_str("0:0,0:1"); # get config directly from a string literal
+/// config = DeviceConfig.from_env("SOME_ENV_KEY")
+/// config = DeviceConfig.from_str("rngd:0:0-3,rngd:0:4-7") # get config directly from a string literal
 /// ```
 ///
 /// The rules for textual representation are as follows:
@@ -42,17 +42,23 @@ use crate::errors::to_py_err;
 /// ```python
 /// from furiosa_device import DeviceConfig
 ///
-/// # Using specific device names
-/// config = DeviceConfig.from_str("warboy:0:0"); # warboy / npu0pe0
-/// config = DeviceConfig.from_str("warboy:0:0-1"); # warboy / npu0pe0-1
+/// # Named configuration examples (using specific device names)
+/// config = DeviceConfig.from_str("warboy:0:0") # warboy, npu0pe0
+/// config = DeviceConfig.from_str("warboy:0:0-1") # warboy, npu0pe0-1
+/// config = DeviceConfig.from_str("rngd:0:0-3") # rngd, npu0pe0-3
+/// config = DeviceConfig.from_str("rngd:1:4-5") # rngd, npu1pe4-5
+/// config = DeviceConfig.from_str("npu:0:0") # warboy, npu0pe0; "npu" is an alias for "warboy" for backward compatibility
 ///
-/// # Using device configs
-/// config = DeviceConfig.from_str("warboy*2"); # single pe x 2 (equivalent to "warboy(1)*2")
-/// config = DeviceConfig.from_str("warboy(1)*2"); # single pe x 2
-/// config = DeviceConfig.from_str("warboy(2)*2"); # 2-pe fusioned x 2
+/// # Unnamed configuration examples
+/// config = DeviceConfig.from_str("warboy*2") # single pe x 2 (equivalent to "warboy(1)*2")
+/// config = DeviceConfig.from_str("warboy(1)*2") # single pe x 2
+/// config = DeviceConfig.from_str("warboy(2)*2") # 2-pe fusioned x 2
+/// config = DeviceConfig.from_str("rngd(1)*2") # single pe x 2
+/// config = DeviceConfig.from_str("rngd(4)*1") # 4-pe fusioned x 1
 ///
-/// # Combine multiple representations separated by commas
-/// config = DeviceConfig.from_str("warboy:0:0-1, warboy:1:0-1"); # warbpy / npu0pe0-1, warboy / npu1pe0-1
+/// # Combining multiple comma-separated representation is also possible.
+/// config = DeviceConfig.from_str("warboy:0:0-1,warboy:1:0-1")
+/// config = DeviceConfig.from_str("warboy:0:0-1,warboy(2)*1") // One named 2-pe warboy (npu0pe0-1), and one anonmyous 2-pe warboy
 /// ```
 #[pyclass(name = "DeviceConfig")]
 #[derive(Clone)]
@@ -73,12 +79,7 @@ impl DeviceConfigPy {
     fn py_new(arch: ArchPy, cores: u8, count: u8) -> PyResult<DeviceConfigPy> {
         let config = match arch {
             ArchPy::Warboy => DeviceConfig::warboy(),
-            _ => {
-                return Err(PyRuntimeError::new_err(format!(
-                    "Invalid architecture: Not supported architecture '{:?}'",
-                    arch
-                )))
-            }
+            ArchPy::RNGD => DeviceConfig::rngd(),
         };
         if !Arch::from(arch.clone()).is_fusible_count(cores) {
             return Err(PyRuntimeError::new_err(format!(

--- a/bindings/python/src/device.rs
+++ b/bindings/python/src/device.rs
@@ -38,10 +38,6 @@ impl CoreStatusPy {
                 status_type: CoreStatusTypePy::Occupied,
                 value: Some(s),
             },
-            CoreStatus::Unavailable => Self {
-                status_type: CoreStatusTypePy::Unavailable,
-                value: None,
-            },
         }
     }
 }

--- a/bindings/python/src/device.rs
+++ b/bindings/python/src/device.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use furiosa_device::perf_regs::{PerformanceCounter, Utilization};
-use furiosa_device::{
-    Arch, ClockFrequency, CoreRange, CoreStatus, Device, DeviceFile, DeviceMode, NumaNode,
-};
+use furiosa_device::{Arch, ClockFrequency, CoreRange, CoreStatus, Device, DeviceFile, NumaNode};
 use pyo3::prelude::*;
 
 use crate::arch::ArchPy;
@@ -288,45 +286,27 @@ enum CoreRangeTypePy {
 #[derive(Clone)]
 pub struct CoreRangePy {
     #[pyo3(get)]
-    range_type: CoreRangeTypePy,
+    start: u8,
     #[pyo3(get)]
-    value: Option<(u8, u8)>,
+    end: u8,
 }
 
 impl CoreRangePy {
     fn new(cr: CoreRange) -> Self {
-        match cr {
-            CoreRange::All => Self {
-                range_type: CoreRangeTypePy::All,
-                value: None,
-            },
-            CoreRange::Range(r) => Self {
-                range_type: CoreRangeTypePy::Range,
-                value: Some(r),
-            },
-        }
+        let CoreRange(s, e) = cr;
+        Self { start: s, end: e }
     }
 }
 
 #[pymethods]
 impl CoreRangePy {
     fn __repr__(&self) -> String {
-        match self.range_type {
-            CoreRangeTypePy::All => String::from("All"),
-            CoreRangeTypePy::Range => format!(
-                "Range ({}, {})",
-                self.value.unwrap().0,
-                self.value.unwrap().1
-            ),
-        }
+        format!("Range ({}, {})", self.start, self.end)
     }
 
     pub fn contains(&self, idx: u8) -> bool {
-        if let Some((s, e)) = self.value {
-            (s..=e).contains(&idx)
-        } else {
-            true
-        }
+        let CoreRangePy { start, end } = self;
+        *start <= idx && idx <= *end
     }
 }
 
@@ -368,24 +348,6 @@ impl DeviceFilePy {
     pub fn core_range(&self) -> CoreRangePy {
         CoreRangePy::new(self.inner.core_range())
     }
-
-    /// Return the mode of this device file.
-    fn mode(&self) -> DeviceModePy {
-        match self.inner.mode() {
-            DeviceMode::Single => DeviceModePy::Single,
-            DeviceMode::Fusion => DeviceModePy::Fusion,
-            DeviceMode::MultiCore => DeviceModePy::MultiCore,
-        }
-    }
-}
-
-/// Enum for NPU's operating mode.
-#[pyclass(name = "DeviceMode")]
-#[derive(Clone)]
-pub enum DeviceModePy {
-    Single,
-    Fusion,
-    MultiCore,
 }
 
 /// An abstraction for a performance counter.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -11,8 +11,7 @@ mod sync;
 use arch::ArchPy;
 use config::DeviceConfigPy;
 use device::{
-    ClockFrequencyPy, CoreRangePy, DeviceFilePy, DeviceModePy, DevicePy, PerformanceCounterPy,
-    UtilizationPy,
+    ClockFrequencyPy, CoreRangePy, DeviceFilePy, DevicePy, PerformanceCounterPy, UtilizationPy,
 };
 use errors::to_py_err;
 
@@ -104,7 +103,6 @@ fn furiosa_device_python(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<FetcherPy>()?;
     m.add_class::<CoreRangePy>()?;
     m.add_class::<ArchPy>()?;
-    m.add_class::<DeviceModePy>()?;
     m.add_class::<ClockFrequencyPy>()?;
     m.add_class::<PerformanceCounterPy>()?;
     m.add_class::<UtilizationPy>()?;

--- a/device-api/src/arch/mod.rs
+++ b/device-api/src/arch/mod.rs
@@ -24,6 +24,20 @@ pub enum Arch {
 }
 
 impl Arch {
+    pub fn num_pe(&self) -> u8 {
+        match self {
+            Arch::WarboyB0 => 2,
+            Arch::Renegade => 8,
+        }
+    }
+
+    pub fn is_fusible_count(&self, count: u8) -> bool {
+        match self {
+            Arch::WarboyB0 => matches!(count, 1 | 2),
+            Arch::Renegade => matches!(count, 1 | 2 | 4),
+        }
+    }
+
     pub(crate) fn devfile_path<P: AsRef<Path>>(&self, devfs: P) -> PathBuf {
         match self {
             Arch::WarboyB0 => devfs.as_ref().to_path_buf(),

--- a/device-api/src/arch/mod.rs
+++ b/device-api/src/arch/mod.rs
@@ -27,14 +27,14 @@ impl Arch {
     pub fn num_pe(&self) -> u8 {
         match self {
             Arch::WarboyB0 => 2,
-            Arch::Renegade => 8,
+            Arch::RNGD => 8,
         }
     }
 
     pub fn is_fusible_count(&self, count: u8) -> bool {
         match self {
             Arch::WarboyB0 => matches!(count, 1 | 2),
-            Arch::Renegade => matches!(count, 1 | 2 | 4),
+            Arch::RNGD => matches!(count, 1 | 2 | 4),
         }
     }
 

--- a/device-api/src/config/inner.rs
+++ b/device-api/src/config/inner.rs
@@ -7,11 +7,10 @@ use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::digit1;
 use nom::combinator::{all_consuming, map, map_res, opt};
-use nom::sequence::{delimited, preceded, separated_pair};
-use nom::Parser;
+use nom::sequence::{delimited, preceded, separated_pair, tuple};
 
 use crate::arch::Arch;
-use crate::device::{CoreRange, DeviceFile, DeviceMode};
+use crate::device::{CoreRange, DeviceFile};
 use crate::{DeviceError, DeviceResult};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
@@ -19,6 +18,9 @@ pub enum Count {
     Finite(u8),
     All,
 }
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
+pub struct Cores(pub(crate) u8);
 
 impl Display for Count {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -57,15 +59,14 @@ impl Display for DeviceConfigInner {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Config {
-    // TODO: Named cannot describe MultiCore yet.
     Named {
-        device_id: u8,
+        arch: Arch,
+        devfile_index: u8,
         core_range: CoreRange,
     },
     Unnamed {
         arch: Arch,
         core_num: u8,
-        mode: DeviceMode,
         count: Count,
     },
 }
@@ -74,16 +75,22 @@ impl Config {
     pub(crate) fn fit(&self, arch: Arch, device_file: &DeviceFile) -> bool {
         match self {
             Self::Named {
-                device_id,
+                arch: config_arch,
+                devfile_index: device_id,
                 core_range,
             } => {
-                device_file.devfile_index() == *device_id && device_file.core_range() == *core_range
+                arch == *config_arch
+                    && device_file.devfile_index() == *device_id
+                    && device_file.core_range() == *core_range
             }
             Self::Unnamed {
                 arch: config_arch,
-                mode,
+                core_num: config_core_num,
                 ..
-            } => arch == *config_arch && device_file.mode() == *mode,
+            } => {
+                let CoreRange(start, end) = device_file.core_range;
+                arch == *config_arch && (end - start + 1) == *config_core_num
+            }
         }
     }
 
@@ -115,6 +122,17 @@ impl FromStr for Config {
     type Err = DeviceError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn parse_arch<'a>(
+        ) -> impl FnMut(&'a str) -> nom::IResult<&'a str, Arch, nom::error::Error<&'a str>>
+        {
+            // TODO: rngd will be added later
+            let p = alt((tag("npu"), tag("warboy")));
+            map_res(p, |s: &str| match s {
+                "npu" | "warboy" => Ok(Arch::WarboyB0),
+                _ => Err(format!("Invalid architecture: {}", s)),
+            })
+        }
+
         fn digit_to_u8<'a>(
         ) -> impl FnMut(&'a str) -> nom::IResult<&'a str, u8, nom::error::Error<&'a str>> {
             map_res(digit1, |s: &str| s.parse::<u8>())
@@ -132,70 +150,45 @@ impl FromStr for Config {
             ))
         }
 
-        // Try parsing a "npu0pe0" pattern. Note that "npu0" is also valid, which represents npu0 as MultiCore mode.
-        fn legacy_parser(s: &str) -> DeviceResult<Config> {
-            let parser_id = preceded(tag("npu"), digit_to_u8());
-            let parser_cores = map(opt(preceded(tag("pe"), parse_cores())), |c| {
-                c.unwrap_or(CoreRange::All)
-            });
-
-            let (_, (device_id, core_range)) = all_consuming(parser_id.and(parser_cores))(s)
-                .map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
-
-            Ok(Config::Named {
-                device_id,
-                core_range,
-            })
-        }
-
-        // Try parsing a "0:0" or "0:0-1" pattern. Note that "0" is also valid, which represents npu0 as MultiCore mode.
+        // Try parsing a "0:0" or "0:0-1" pattern.
         fn named_cfg_parser(s: &str) -> DeviceResult<Config> {
-            let parser_id = preceded(tag("npu:"), digit_to_u8());
-            let parser_cores = map(opt(preceded(tag(":"), parse_cores())), |c| {
-                c.unwrap_or(CoreRange::All)
-            });
+            let parser_arch = parse_arch();
+            let parser_id = preceded(tag(":"), digit_to_u8());
+            let parser_cores = preceded(tag(":"), parse_cores());
+            let mut parser = all_consuming(tuple((parser_arch, parser_id, parser_cores)));
 
-            let (_, (device_id, core_range)) = all_consuming(parser_id.and(parser_cores))(s)
-                .map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
+            let (_, (arch, devfile_index, core_range)) =
+                parser(s).map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
 
             Ok(Config::Named {
-                device_id,
+                arch,
+                devfile_index,
                 core_range,
             })
         }
 
         // Try parsing a "warboy(1)*1" pattern
         fn unnamed_cfg_parser(s: &str) -> DeviceResult<Config> {
-            // Currently supports "warboy" only
+            // TODO: rngd will be added later
             let parser_arch = map_res(tag("warboy"), |s: &str| s.parse::<Arch>());
-            let parser_mode =
-                map(
-                    opt(delimited(tag("("), digit_to_u8(), tag(")"))),
-                    |mode| match mode {
-                        // "warboy" is equivalent to "warboy(1)"
-                        None | Some(1) => (1, DeviceMode::Single),
-                        // TODO: Improve below
-                        Some(n) => (n, DeviceMode::Fusion),
-                    },
-                );
+            let parser_cores = map(opt(delimited(tag("("), digit_to_u8(), tag(")"))), |c| {
+                c.unwrap_or(1)
+            });
             let parser_count = preceded(tag("*"), digit_to_u8());
+            let mut parser = all_consuming(tuple((parser_arch, parser_cores, parser_count)));
 
             // Note: nom::sequence::tuple requires parsers to have equivalent signatures
-            let (_, ((arch, (core_num, mode)), count)) =
-                all_consuming(parser_arch.and(parser_mode).and(parser_count))(s)
-                    .map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
+            let (_, (arch, core_num, count)) =
+                parser(s).map_err(|e| DeviceError::parse_error(s, e.to_string()))?;
 
             Ok(Config::Unnamed {
                 arch,
                 core_num,
-                mode,
                 count: Count::Finite(count),
             })
         }
 
-        legacy_parser(s)
-            .or_else(|_| named_cfg_parser(s))
-            .or_else(|_| unnamed_cfg_parser(s))
+        named_cfg_parser(s).or_else(|_| unnamed_cfg_parser(s))
     }
 }
 
@@ -203,24 +196,20 @@ impl Display for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Named {
-                device_id,
+                arch,
+                devfile_index: device_id,
                 core_range,
-            } => match core_range {
-                CoreRange::All => {
-                    write!(f, "npu:{device_id}")
+            } => {
+                let CoreRange(start, end) = core_range;
+                if start == end {
+                    write!(f, "{arch}:{device_id}:{start}")
+                } else {
+                    write!(f, "{arch}:{device_id}:{start}-{end}")
                 }
-                CoreRange::Range((s, e)) => {
-                    if s == e {
-                        write!(f, "npu:{device_id}:{s}")
-                    } else {
-                        write!(f, "npu:{device_id}:{s}-{e}")
-                    }
-                }
-            },
+            }
             Self::Unnamed {
                 arch,
                 core_num,
-                mode: _mode,
                 count,
             } => {
                 if *core_num == 0 {
@@ -239,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_multiple_configs_repr() -> eyre::Result<()> {
-        let repr = "npu:0:0,npu:0:1";
+        let repr = "warboy:0:0,warboy:0:1";
         let config = repr.parse::<DeviceConfigInner>()?;
 
         assert_eq!(repr, config.to_string().as_str());
@@ -289,47 +278,38 @@ mod tests {
         assert!("npu0:".parse::<Config>().is_err());
         assert!("npu:0:0-1-".parse::<Config>().is_err());
         assert!("npu:0:1-0".parse::<Config>().is_err());
+        assert!("npu:0".parse::<Config>().is_err());
 
-        assert_eq!(
-            "npu:0".parse::<Config>()?,
-            Config::Named {
-                device_id: 0,
-                core_range: CoreRange::All
-            }
-        );
-        assert_eq!(
-            "npu:1".parse::<Config>()?,
-            Config::Named {
-                device_id: 1,
-                core_range: CoreRange::All
-            }
-        );
         assert_eq!(
             "npu:0:0".parse::<Config>()?,
             Config::Named {
-                device_id: 0,
-                core_range: CoreRange::Range((0, 0))
+                arch: Arch::WarboyB0,
+                devfile_index: 0,
+                core_range: CoreRange(0, 0)
             }
         );
         assert_eq!(
             "npu:0:1".parse::<Config>()?,
             Config::Named {
-                device_id: 0,
-                core_range: CoreRange::Range((1, 1))
+                arch: Arch::WarboyB0,
+                devfile_index: 0,
+                core_range: CoreRange(1, 1)
             }
         );
         assert_eq!(
             "npu:1:1".parse::<Config>()?,
             Config::Named {
-                device_id: 1,
-                core_range: CoreRange::Range((1, 1))
+                arch: Arch::WarboyB0,
+                devfile_index: 1,
+                core_range: CoreRange(1, 1)
             }
         );
         assert_eq!(
             "npu:0:0-1".parse::<Config>()?,
             Config::Named {
-                device_id: 0,
-                core_range: CoreRange::Range((0, 1))
+                arch: Arch::WarboyB0,
+                devfile_index: 0,
+                core_range: CoreRange(0, 1)
             }
         );
 
@@ -348,7 +328,6 @@ mod tests {
             Config::Unnamed {
                 arch: Arch::WarboyB0,
                 core_num: 1,
-                mode: DeviceMode::Single,
                 count: Count::Finite(2),
             }
         );
@@ -357,7 +336,6 @@ mod tests {
             Config::Unnamed {
                 arch: Arch::WarboyB0,
                 core_num: 2,
-                mode: DeviceMode::Fusion,
                 count: Count::Finite(4)
             }
         );
@@ -366,42 +344,7 @@ mod tests {
             Config::Unnamed {
                 arch: Arch::WarboyB0,
                 core_num: 1,
-                mode: DeviceMode::Single,
                 count: Count::Finite(12)
-            }
-        );
-        // assert!("npu*10".parse::<Config>().is_ok());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_from_legacy_text_repr() -> eyre::Result<()> {
-        assert!("npu0pe".parse::<Config>().is_err());
-        assert!("npupe0".parse::<Config>().is_err());
-        assert!("npu0pe0,".parse::<Config>().is_err());
-
-        assert_eq!(
-            "npu1pe1".parse::<Config>()?,
-            Config::Named {
-                device_id: 1,
-                core_range: CoreRange::Range((1, 1))
-            }
-        );
-
-        assert_eq!(
-            "npu1pe0-1".parse::<Config>()?,
-            Config::Named {
-                device_id: 1,
-                core_range: CoreRange::Range((0, 1))
-            }
-        );
-
-        assert_eq!(
-            "npu1".parse::<Config>()?,
-            Config::Named {
-                device_id: 1,
-                core_range: CoreRange::All
             }
         );
 

--- a/device-api/src/config/mod.rs
+++ b/device-api/src/config/mod.rs
@@ -42,10 +42,8 @@ use crate::{Arch, DeviceError};
 /// use std::str::FromStr;
 ///
 /// use furiosa_device::DeviceConfig;
-///
-/// let config = DeviceConfig::from_env("SOME_OTHER_ENV_KEY").build();
-/// let config = DeviceConfig::from_str("warboy:0:0,warboy:0:1").unwrap(); // get config directly from a string literal
-/// let config = DeviceConfig::from_str("npu:0:0,npu:0:1").unwrap(); // equivalent: you can use "npu" instead of "warboy"
+/// let config = DeviceConfig::from_env("SOME_ENV_KEY").build(); // get config from an environment variable
+/// let config = DeviceConfig::from_str("rngd:0:0-3,rngd:0:4-7").unwrap(); // get config directly from textual representation
 /// ```
 ///
 /// The rules for textual representation are as follows:
@@ -55,17 +53,23 @@ use crate::{Arch, DeviceError};
 ///
 /// use furiosa_device::DeviceConfig;
 ///
-/// // Using specific device names
-/// DeviceConfig::from_str("npu:0:0").unwrap(); // warboy, npu0pe0
-/// DeviceConfig::from_str("npu:0:0-1").unwrap(); // warboy, npu0pe0-1
+/// // Named configuration examples (using specific device names)
+/// DeviceConfig::from_str("warboy:0:0").unwrap(); // warboy, npu0pe0
+/// DeviceConfig::from_str("warboy:0:0-1").unwrap(); // warboy, npu0pe0-1
+/// DeviceConfig::from_str("rngd:0:0-3").unwrap(); // rngd, npu0pe0-3
+/// DeviceConfig::from_str("rngd:1:4-5").unwrap(); // rngd, npu1pe4-5
+/// DeviceConfig::from_str("npu:0:0").unwrap(); // warboy, npu0pe0; "npu" is an alias for "warboy" for backward compatibility
 ///
-/// // Using device configs
+/// // Unnamed configuration examples
 /// DeviceConfig::from_str("warboy*2").unwrap(); // single pe x 2 (equivalent to "warboy(1)*2")
 /// DeviceConfig::from_str("warboy(1)*2").unwrap(); // single pe x 2
 /// DeviceConfig::from_str("warboy(2)*2").unwrap(); // 2-pe fusioned x 2
+/// DeviceConfig::from_str("rngd(1)*2").unwrap(); // single pe x 2
+/// DeviceConfig::from_str("rngd(4)*1").unwrap(); // 4-pe fusioned x 1
 ///
-/// // Combine multiple representations separated by commas
-/// DeviceConfig::from_str("npu:0:0-1,npu:1:0-1").unwrap(); // npu0pe0-1, npu1pe0-1
+/// // Combining multiple comma-separated representation is also possible.
+/// DeviceConfig::from_str("warboy:0:0-1,warboy:1:0-1").unwrap();
+/// DeviceConfig::from_str("warboy:0:0-1,warboy(2)*1").unwrap(); // One named 2-pe warboy (npu0pe0-1), and one anonmyous 2-pe warboy
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(into = "String", try_from = "&str")]
@@ -78,6 +82,15 @@ impl DeviceConfig {
     pub fn warboy() -> DeviceConfigBuilder<Arch, NotDetermined, NotDetermined> {
         DeviceConfigBuilder {
             arch: Arch::WarboyB0,
+            cores: NotDetermined { _priv: () },
+            count: NotDetermined { _priv: () },
+        }
+    }
+
+    /// Returns a builder associated with RNGD NPUs.
+    pub fn rngd() -> DeviceConfigBuilder<Arch, NotDetermined, NotDetermined> {
+        DeviceConfigBuilder {
+            arch: Arch::RNGD,
             cores: NotDetermined { _priv: () },
             count: NotDetermined { _priv: () },
         }

--- a/device-api/src/device.rs
+++ b/device-api/src/device.rs
@@ -333,7 +333,6 @@ pub enum NumaNode {
 pub enum CoreStatus {
     Available,
     Occupied(String),
-    Unavailable,
 }
 
 impl Display for CoreStatus {
@@ -341,7 +340,6 @@ impl Display for CoreStatus {
         match self {
             CoreStatus::Available => write!(f, "available"),
             CoreStatus::Occupied(devfile) => write!(f, "occupied by {devfile}"),
-            CoreStatus::Unavailable => write!(f, "unavailable"),
         }
     }
 }
@@ -586,7 +584,6 @@ mod tests {
     #[test]
     fn test_core_status_fmt() {
         assert_eq!(format!("{}", CoreStatus::Available), "available");
-        assert_eq!(format!("{}", CoreStatus::Unavailable), "unavailable");
         assert_eq!(
             format!("{}", CoreStatus::Occupied(String::from("npu0pe0"))),
             "occupied by npu0pe0"

--- a/device-api/src/device.rs
+++ b/device-api/src/device.rs
@@ -248,7 +248,8 @@ impl Device {
     pub async fn get_status_core(&self, core: CoreIdx) -> DeviceResult<CoreStatus> {
         for file in &self.dev_files {
             // get status of the exact core
-            if file.mode() != DeviceMode::Single {
+            let CoreRange(start, end) = file.core_range();
+            if start != end {
                 continue;
             }
             if (file.core_range().contains(&core))
@@ -348,43 +349,24 @@ impl Display for CoreStatus {
 pub(crate) type CoreIdx = u8;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
-pub enum CoreRange {
-    All, // TODO: rename this to MultiCore
-    // This range is inclusive [s, e]
-    Range((u8, u8)),
-}
+pub struct CoreRange(pub u8, pub u8);
 
 impl CoreRange {
     pub fn contains(&self, idx: &CoreIdx) -> bool {
-        match self {
-            CoreRange::All => true,
-            CoreRange::Range((s, e)) => (*s..=*e).contains(idx),
-        }
+        let CoreRange(start, end) = self;
+        start <= idx && idx <= end
     }
 
     pub fn has_intersection(&self, other: &Self) -> bool {
-        match (self, other) {
-            (CoreRange::All, _) | (_, CoreRange::All) => true,
-            (CoreRange::Range(a), CoreRange::Range(b)) => !(a.1 < b.0 || b.1 < a.0),
-        }
+        self.contains(&other.0) || self.contains(&other.1)
     }
 }
 
 impl Ord for CoreRange {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self {
-            CoreRange::All => {
-                if self == other {
-                    std::cmp::Ordering::Equal
-                } else {
-                    std::cmp::Ordering::Less
-                }
-            }
-            CoreRange::Range(r) => match other {
-                CoreRange::All => std::cmp::Ordering::Greater,
-                CoreRange::Range(other) => (r.1 - r.0).cmp(&(other.1 - other.0)).then(r.cmp(other)),
-            },
-        }
+        (self.1 - self.0)
+            .cmp(&(other.1 - other.0))
+            .then(self.0.cmp(&other.0))
     }
 }
 
@@ -396,7 +378,7 @@ impl PartialOrd for CoreRange {
 
 impl From<u8> for CoreRange {
     fn from(id: u8) -> Self {
-        Self::Range((id, id))
+        Self(id, id)
     }
 }
 
@@ -404,7 +386,7 @@ impl TryFrom<(u8, u8)> for CoreRange {
     type Error = ();
     fn try_from(v: (u8, u8)) -> Result<Self, Self::Error> {
         if v.0 < v.1 {
-            Ok(Self::Range(v))
+            Ok(Self(v.0, v.1))
         } else {
             Err(())
         }
@@ -417,7 +399,6 @@ pub struct DeviceFile {
     pub(crate) devfile_index: u8,
     pub(crate) core_range: CoreRange,
     pub(crate) path: PathBuf,
-    pub(crate) mode: DeviceMode,
 }
 
 impl Display for DeviceFile {
@@ -464,11 +445,6 @@ impl DeviceFile {
         self.core_range
     }
 
-    /// Return the mode of this device file.
-    pub fn mode(&self) -> DeviceMode {
-        self.mode
-    }
-
     pub fn has_intersection(&self, other: &Self) -> bool {
         self.devfile_index() == other.devfile_index()
             && self.core_range().has_intersection(&other.core_range())
@@ -487,32 +463,19 @@ impl TryFrom<&PathBuf> for DeviceFile {
 
         let (devfile_index, core_indices) = devfs::parse_indices(file_name)?;
 
-        let (mode, core_range) = match core_indices.len() {
-            0 => (DeviceMode::MultiCore, CoreRange::All),
-            1 => (DeviceMode::Single, CoreRange::from(core_indices[0])),
-            n => (
-                DeviceMode::Fusion,
-                CoreRange::try_from((core_indices[0], core_indices[n - 1]))
-                    .map_err(|_| DeviceError::unrecognized_file(path.to_string_lossy()))?,
-            ),
+        let core_range = match core_indices.len() {
+            0 => return Err(DeviceError::unrecognized_file(path.to_string_lossy())),
+            1 => CoreRange::from(core_indices[0]),
+            n => CoreRange::try_from((core_indices[0], core_indices[n - 1]))
+                .map_err(|_| DeviceError::unrecognized_file(path.to_string_lossy()))?,
         };
 
         Ok(DeviceFile {
             devfile_index,
             core_range,
             path: path.clone(),
-            mode,
         })
     }
-}
-
-/// Enum for NPU's operating mode.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, enum_utils::FromStr, PartialOrd)]
-#[enumeration(case_insensitive)]
-pub enum DeviceMode {
-    Single,
-    Fusion,
-    MultiCore,
 }
 
 lazy_static! {
@@ -565,14 +528,12 @@ mod tests {
 
     #[test]
     fn test_core_range_ordering() {
-        let all = CoreRange::All;
-        let core0 = CoreRange::Range((0, 0));
-        let core1 = CoreRange::Range((1, 1));
-        let core0_1 = CoreRange::Range((0, 1));
-        let core0_3 = CoreRange::Range((0, 3));
-        let core2_3 = CoreRange::Range((2, 3));
+        let core0 = CoreRange(0, 0);
+        let core1 = CoreRange(1, 1);
+        let core0_1 = CoreRange(0, 1);
+        let core0_3 = CoreRange(0, 3);
+        let core2_3 = CoreRange(2, 3);
 
-        assert!(all < core0);
         assert!(core0 < core1);
         assert!(core1 < core0_1);
         assert!(core0_1 < core2_3);
@@ -581,23 +542,16 @@ mod tests {
 
     #[test]
     fn test_try_from() -> Result<(), DeviceError> {
-        assert_eq!(
-            DeviceFile::try_from(&PathBuf::from("./npu0"))?,
-            DeviceFile {
-                devfile_index: 0,
-                path: PathBuf::from("./npu0"),
-                core_range: CoreRange::All,
-                mode: DeviceMode::MultiCore,
-            }
-        );
+        let expected_err = DeviceFile::try_from(&PathBuf::from("./npu0"));
+        assert!(expected_err.is_err());
+
         assert!(DeviceFile::try_from(&PathBuf::from("./npu0pe")).is_err());
         assert_eq!(
             DeviceFile::try_from(&PathBuf::from("./npu0pe0"))?,
             DeviceFile {
                 devfile_index: 0,
                 path: PathBuf::from("./npu0pe0"),
-                core_range: CoreRange::Range((0, 0)),
-                mode: DeviceMode::Single,
+                core_range: CoreRange(0, 0),
             }
         );
         assert_eq!(
@@ -605,8 +559,7 @@ mod tests {
             DeviceFile {
                 devfile_index: 0,
                 path: PathBuf::from("./npu0pe1"),
-                core_range: CoreRange::Range((1, 1)),
-                mode: DeviceMode::Single,
+                core_range: CoreRange(1, 1),
             }
         );
         assert_eq!(
@@ -614,8 +567,7 @@ mod tests {
             DeviceFile {
                 devfile_index: 0,
                 path: PathBuf::from("./npu0pe0-1"),
-                core_range: CoreRange::Range((0, 1)),
-                mode: DeviceMode::Fusion,
+                core_range: CoreRange(0, 1),
             }
         );
         assert_eq!(
@@ -623,8 +575,7 @@ mod tests {
             DeviceFile {
                 devfile_index: 0,
                 path: PathBuf::from("./npu0pe0-2"),
-                core_range: CoreRange::Range((0, 2)),
-                mode: DeviceMode::Fusion,
+                core_range: CoreRange(0, 2),
             }
         );
         assert!(DeviceFile::try_from(&PathBuf::from("./npu0pe0-")).is_err());
@@ -640,17 +591,6 @@ mod tests {
             format!("{}", CoreStatus::Occupied(String::from("npu0pe0"))),
             "occupied by npu0pe0"
         );
-    }
-
-    #[test]
-    fn test_device_mode_from_str() {
-        assert_eq!("single".parse(), Ok(DeviceMode::Single));
-        assert_eq!("SiNgLe".parse(), Ok(DeviceMode::Single));
-        assert_eq!("fusion".parse(), Ok(DeviceMode::Fusion));
-        assert_eq!("fUsIoN".parse(), Ok(DeviceMode::Fusion));
-        assert_eq!("multicore".parse(), Ok(DeviceMode::MultiCore));
-        assert_eq!("MultiCore".parse(), Ok(DeviceMode::MultiCore));
-        assert_eq!("invalid".parse::<DeviceMode>(), Err(()));
     }
 
     #[test]

--- a/device-api/src/lib.rs
+++ b/device-api/src/lib.rs
@@ -44,7 +44,7 @@
 //! // Find two Warboy devices, fused.
 //! # #[tokio::main]
 //! # async fn main() -> eyre::Result<()> {
-//! let config = DeviceConfig::warboy().fused().count(2);
+//! let config = DeviceConfig::warboy().cores(2).count(2);
 //! let dev_files = find_device_files(&config).await?;
 //! # Ok(())
 //! # }
@@ -67,9 +67,7 @@
 pub use crate::arch::Arch;
 use crate::config::{expand_status, find_device_files_in};
 pub use crate::config::{DeviceConfig, DeviceConfigBuilder, EnvBuilder, NotDetermined};
-pub use crate::device::{
-    ClockFrequency, CoreRange, CoreStatus, Device, DeviceFile, DeviceMode, NumaNode,
-};
+pub use crate::device::{ClockFrequency, CoreRange, CoreStatus, Device, DeviceFile, NumaNode};
 pub use crate::error::{DeviceError, DeviceResult};
 use crate::list::list_devices_with;
 


### PR DESCRIPTION
This PR introduces two changes.

### 1. Deprecation of `DeviceMode` and Changes in `DeviceConfig`

`DeviceMode::MultiCore` is no longer supported, rendering `DeviceMode` unnecessary as there is sufficient information in `CoreRange` to determine fusion.

Due to this, `DeviceConfig` has undergone significant changes:
- Removal of `.fused()`. Users must now explicitly specify the number of PEs to fuse using `.cores(N)`.
- Elimination of device configuration via device filenames like `npu0pe0`, since device filenames are not unique among different `Arch`s.

### 2. Deprecation of `CoreStatus::Unavailable`

This status previously indicated that at least one core in a range was `Occupied` by another process. Since this concept overlaps with `Occupied`, we now return the first `Occupied` status when a range is unavailable.

### Request for Feedback:

There may be a better design around `.cores(N)`. My concerns are:

- The term "core" is inaccurate, as (1) the correct term is "PE" and (2) "cores" may imply multicore functionality. Perhaps a term like `.fusing(N)` might be more appropriate?
- Users are now able to specify any number `N` for fusion, even when `N` is not feasible. This might not cause runtime issues, as non-fusible `N` does not correspond to any `DeviceFile`s, but anyway this design requires users to understand our fusion mechanism better.

Feedback on these points is highly appreciated.
